### PR TITLE
Lexer

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,10 @@
+# EditorConfig is awesome: http://EditorConfig.org
+root = true
+
+[*]
+end_of_line = lf
+insert_final_newline = true
+
+[*.lua]
+indent_style = space
+indent_size = 4

--- a/spec/lexer_spec.lua
+++ b/spec/lexer_spec.lua
@@ -1,0 +1,240 @@
+local lexer = require 'titan-compiler.lexer'
+local lpeg = require 'lpeglabel'
+
+local function table_extend(t1, t2)
+    table.move(t2, 1, #t2, #t1+1, t1)
+end
+
+-- Find out how the lexer lexes a given string.
+-- Produces an error message if the string cannot be lexed or if there
+-- are multiple ways to lex it.
+local function run_lexer(source)
+    local all_matched_tokens = {}
+    local all_captures = {}
+
+    local i = 1
+    while i <= #source do
+
+        local found_token = nil
+        local found_captures = nil
+        local found_j = nil
+
+        for tokname, tokpat in pairs(lexer) do
+            local captures, j = lpeg.match(lpeg.Ct(tokpat) * lpeg.Cp(), source, i)
+            if captures then
+                if i == j then
+                    return string.format(
+                        "error: token %s matched the empty string",
+                        tokname)
+                elseif found_token then
+                    return string.format(
+                        "error: multiple matching tokens: %s %s",
+                         found_token, tokname)
+                else
+                    found_token = tokname
+                    found_captures = captures
+                    found_j = j
+                end
+            end
+        end
+
+        if not found_token then
+            return "error: lexer got stuck"
+        end
+
+        table.insert(all_matched_tokens, found_token)
+        table_extend(all_captures, found_captures)
+        i = found_j
+    end
+
+    return { tokens = all_matched_tokens, captures = all_captures }
+end
+
+local function assert_lex(source, expected_tokens, expected_captures)
+    local lexed    = run_lexer(source)
+    local expected = { tokens = expected_tokens, captures = expected_captures }
+    assert.are.same(expected, lexed)
+end
+
+describe("Titan lexer", function()
+
+    it("can lex some keywords", function()
+        assert_lex("and", {"AND"}, {})
+    end)
+
+    it("can lex keywords that contain other keywords", function()
+        assert_lex("if",     {"IF"},     {})
+        assert_lex("else",   {"ELSE"},   {})
+        assert_lex("elseif", {"ELSEIF"}, {})
+    end)
+
+    it("does not generate semantic values for keywords", function()
+        assert_lex("nil",   {"NIL"},   {})
+        assert_lex("true",  {"TRUE"},  {})
+        assert_lex("false", {"FALSE"}, {})
+    end)
+
+    it("can lex some identifiers", function()
+        assert_lex("hello",    {"NAME"}, {"hello"})
+        assert_lex("_",        {"NAME"}, {"_"})
+        assert_lex("_test_17", {"NAME"}, {"_test_17"})
+    end)
+
+    it("can lex identifiers containing keywords", function()
+        assert_lex("return17", {"NAME"}, {"return17"})
+        assert_lex("andy",     {"NAME"}, {"andy"})
+        assert_lex("_end",     {"NAME"}, {"_end"})
+    end)
+
+    it("can lex sequences of symbols without spaces", function()
+        assert_lex("+++", {"ADD", "ADD", "ADD"}, {})
+        assert_lex(".",   {"DOT"},               {})
+        assert_lex("..",  {"CONCAT"},            {})
+        assert_lex("...", {"DOTS"},              {})
+        assert_lex("<==", {"LE", "ASSIGN"},      {})
+        assert_lex("---", {"COMMENT"},           {})
+        assert_lex("///", {"IDIV", "DIV"},       {})
+        assert_lex("~=",  {"NE"},                {})
+        assert_lex("~~=", {"BXOR", "NE"},        {})
+    end)
+    
+    it("can lex some integers", function()
+        assert_lex("0",            {"NUMBER"}, {0})
+        assert_lex("17",           {"NUMBER"}, {17})
+        assert_lex("0x1abcdef",    {"NUMBER"}, {0x1abcdef})
+        assert_lex("0x1ABCDEF",    {"NUMBER"}, {0x1ABCDEF})
+    end)
+
+    it("can lex some floats", function()
+        assert_lex("0.0",          {"NUMBER"}, {0.0})
+        assert_lex("0.",           {"NUMBER"}, {0.})
+        assert_lex(".0",           {"NUMBER"}, {.0})
+        assert_lex("1.0e+1",       {"NUMBER"}, {1.0e+1})
+        assert_lex("1.0e-1",       {"NUMBER"}, {1.0e-1})
+        assert_lex("1e10",         {"NUMBER"}, {1e10})
+        assert_lex("1E10",         {"NUMBER"}, {1E10})
+        assert_lex("0x1ap2",       {"NUMBER"}, {0x1ap2})
+    end)
+
+    it("does the right thing with dots touching numbers", function()
+        assert_lex(".1",   {"NUMBER"},           {.1})
+        assert_lex("..2",  {"CONCAT", "NUMBER"}, {2})
+        assert_lex("...3", {"DOTS", "NUMBER"},   {3})
+        assert_lex("4.",   {"NUMBER"},           {4})
+    end)
+
+    it("errors out on invalid numbers (instead of backtracking)", function()
+        pending('implement syntax errors')
+        -- 1abcdef
+        -- 1.2.3.4
+        -- 1e
+        -- 1e2e3
+        -- 1p5
+
+        -- .1.
+        -- 4..
+        
+        -- local x = 1337require        -- this is accepted by Lua (!)
+        -- local x = 1337collectgarbage -- this is rejected by Lua (x is hexdigit)
+        -- 
+    end)
+
+    it("can lex some short strings", function()
+        assert_lex([[""]], {"STRING"}, {""})
+        assert_lex([["asdf"]], {"STRING"}, {"asdf"})
+    end)
+
+    it("doesn't eat the spaces inside a string", function()
+        assert_lex([[" asdf  "]], {"STRING"}, {" asdf  "})
+    end)
+
+    it("can lex short strings containg quotes", function()
+        assert_lex([["O'Neil"]],    {"STRING"}, {"O\'Neil"})
+        assert_lex([['aa"bb"cc']],  {"STRING"}, {"aa\"bb\"cc"})
+    end)
+
+    it("can lex short strings containing escape sequences", function()
+        assert_lex([["\a\b\f\n\r\t\v\\\'\""]], {"STRING"}, {"\a\b\f\n\r\t\v\\\'\""})
+    end)
+
+    it("can lex short strings containing escaped newlines", function()
+        assert_lex('"A\\\nB"',   {"STRING"}, {"A\nB"})
+        assert_lex('"A\\\rB"',   {"STRING"}, {"A\nB"})
+        assert_lex('"A\\\n\rB"', {"STRING"}, {"A\nB"})
+        assert_lex('"A\\\r\nB"', {"STRING"}, {"A\nB"})
+    end)
+
+    it("errors out on invalid excape sequences (instead of backtracking)", function()
+        pending("implement syntax errors")
+        -- error "\o"
+    end)
+
+    it("errors out on unclosed strings (instead of backtracking)", function()
+        pending("implement syntax errors")
+        -- error "'
+        -- error "A
+        -- error "A\n
+        -- error "A\r
+        -- error "A\\\n\nB"
+        -- error "A\\\r\rB"
+        -- error [[]]
+        -- error [[]=]
+    end)
+
+    it("can lex some long strings", function()
+        assert_lex("[[abc\\o\\x\"\'def]]", {"STRING"}, {"abc\\o\\x\"\'def"})
+        assert_lex("[[ ]===] ]]",          {"STRING"}, {" ]===] "})
+    end)
+
+    it("can lex long strings with overlaping close brackets", function()
+        assert_lex("[==[ Hi ]]]]=]==]", {"STRING"}, {" Hi ]]]]="})
+    end)
+    
+    it("can lex long strings touching square brackets", function()
+        assert_lex("[[[a]]]", {"STRING", "RBRACKET"}, {"[a"})
+        assert_lex("[  [[a]]]", {"LBRACKET", "SPACE", "STRING", "RBRACKET"}, {"a"})
+    end)
+
+    it("ignores newlines at the start of a long string", function()
+        assert_lex("[[\nhello]]",   {"STRING"}, {"hello"})
+        assert_lex("[[\rhello]]",   {"STRING"}, {"hello"})
+        assert_lex("[[\n\rhello]]", {"STRING"}, {"hello"})
+        assert_lex("[[\r\nhello]]", {"STRING"}, {"hello"})
+        assert_lex("[[\n\nhello]]", {"STRING"}, {"\nhello"})
+        assert_lex("[[\r\rhello]]", {"STRING"}, {"\rhello"})
+    end)
+
+    it("can lex some short comments", function()
+        assert_lex("if--then\nelse", {"IF", "COMMENT", "ELSE"}, {})
+    end)
+
+    it("can lex short comments that go until the end of the file", function()
+        assert_lex("--aaaa", {"COMMENT"}, {})
+    end)
+
+    it("can lex long some comments", function()
+        assert_lex("if--[[a\n\n\n]]else", {"IF", "COMMENT", "ELSE"}, {})
+
+        assert_lex(
+            "--[[\n" ..
+            "return 1\n" ..
+            "--]]",
+            {"COMMENT"}, {}
+        )
+        
+        assert_lex(
+            "---[[\n" ..
+            "return 1\n" ..
+            "--]]",
+            {"COMMENT", "RETURN", "SPACE", "NUMBER", "SPACE", "COMMENT"}, {1}
+        )
+
+    end)
+
+    it("can lex some programs", function()
+        assert_lex("local x: float = 10.0",
+            {"LOCAL", "SPACE", "NAME", "COLON", "SPACE", "NAME",
+             "SPACE", "ASSIGN", "SPACE", "NUMBER"},
+            {"x", "float", 10.0})
+    end)
+end)

--- a/titan-compiler/lexer.lua
+++ b/titan-compiler/lexer.lua
@@ -1,0 +1,221 @@
+--
+-- This module exports lpeg patterns that can lex Titan source code.
+--
+-- The lexer follows the "longest match" rule and for any given input there
+-- will be at most one token that matches it. For example, lexer.LE matches
+-- the start of "<=bla" but lexer.LT doesn't. This should mean that you don't
+-- need to worry about what token comes first in a PEG ordered choice or about
+-- the lexer splitting words in the middle (such as "localx" being parsed as
+-- "local" "x").
+--
+-- The exported tokens are in ALLCAPS, to play nice with the "re"-style grammars
+-- from parser-gen: it can only refer to our tokens if we use alphabetical
+-- identifiers and it expects terminals to be uppercase and non-terminals to be
+-- lowercase.
+
+local lpeg = require 'lpeglabel'
+
+local P, R, S = lpeg.P, lpeg.R, lpeg.S
+local C, Cmt  = lpeg.C, lpeg.Cmt
+
+local lexer = {}
+
+local function lex_error(message)
+    -- TODO: figure this out
+    error(message)
+end
+
+--
+-- Numbers
+--
+
+-- This very general pattern matches both integer and floating point numbers,
+-- in either decimal or hexadecimal notation, as well as a bunch of invalid
+-- stuff. We use tonumber in the end to find out which is which. This pattern
+-- is intentionally more general than the one that Lua uses to avoid allowing
+-- weird things such as `1337require`.
+local number_start = P(".")^-1 * R("09")
+local expo = S("EePp") * S("+-")^-1
+local possible_number = #number_start * (expo + R("09", "AZ", "az") + ".")^1
+lexer.NUMBER = Cmt(possible_number, function(_, i, s)
+    local n = tonumber(s)
+    if n then
+        return i, n
+    else
+        lex_error("todo: nice syntax error for malformed number")
+    end
+end)
+
+--
+-- Strings
+--
+
+-- If source[i] points to a newline sequence, skip it.
+-- We use Lua's definition of newline sequence.
+local function skip_linebreak(source, i)
+    if string.match(source, "^\n\r", i) then return i + 2 end
+    if string.match(source, "^\r\n", i) then return i + 2 end
+    if string.match(source, "^\n", i)   then return i + 1 end
+    if string.match(source, "^\r", i)   then return i + 1 end
+    return i
+end
+
+local longstring_open  = P("[") * C( P("=")^0 ) * P("[")
+local longstring = Cmt(longstring_open, function(source, i, equals)
+    i = skip_linebreak(source, i)
+    local close_str = "]" .. equals .. "]"
+    local j, k = string.find(source, close_str, i, true)
+    if j then
+        return k+1, string.sub(source, i, j-1)
+    else
+        lex_error("TODO: friendly syntax error for EOF")
+    end
+end)
+
+local simple_escapes = {
+    ["a"]  = "\a",
+    ["b"]  = "\b",
+    ["f"]  = "\f",
+    ["n"]  = "\n",
+    ["r"]  = "\r",
+    ["t"]  = "\t",
+    ["v"]  = "\v",
+    ["\\"] = "\\",
+    ["\'"] = "\'",
+    ["\""] = "\"",
+}
+
+local function do_string_escape(source, i, parts)
+    if i > #source then
+        return nil
+    end
+
+    local c = string.sub(source,i,i);
+    i = i + 1
+    
+    if simple_escapes[c] then
+        table.insert(parts, simple_escapes[c])
+    elseif c == "\n" or c == "\r" then
+        table.insert(parts, "\n") -- Same behaviour as Lua
+        i = skip_linebreak(source, i-1)
+    elseif string.match(c, "^[0-9]$") then
+        lex_error("TODO: implement \\ddd escapes")
+    elseif c == "u" then
+        lex_error("TODO: implement \\u escapes")
+    elseif c == "x" then
+        lex_error("TODO: implement \\x escapes")
+    elseif c == "z" then
+        lex_error("TODO: implement \\z")
+    else
+        lex_error("TODO: friendly syntax error for unknown escape")
+    end
+
+    return i
+end
+
+local shortstring = Cmt( C(P('"') + P("'")), function(source, i, delimiter)
+    local parts = {}
+
+    while i <= #source do
+        
+        local c = string.sub(source,i,i);
+        i = i + 1
+
+        if c == delimiter then
+            return i, table.concat(parts)
+        elseif c == "\n" or c == "\r" then
+            lex_error("TODO: friendly syntax error for unfinished string (\\n)")
+        elseif c == "\\" then
+            i = do_string_escape(source, i, parts)
+            if not i then break end -- EOF error
+        else
+            table.insert(parts, c)
+        end
+    end
+
+    lex_error("TODO: friendly syntax error for unfinished string (EOF)")
+end)
+
+lexer.STRING = shortstring + longstring
+
+--
+-- Spaces and Comments
+--
+
+lexer.SPACE = S(" \t\n\v\f\r")^1
+
+local comment_start = P("--")
+local short_comment = comment_start * (P(1) - P("\n"))^0 * P("\n")^-1
+local long_comment  = comment_start * longstring / function() end
+
+lexer.COMMENT = long_comment + short_comment
+
+--
+-- Keywords and names
+--
+
+local idstart = P("_") + R("AZ", "az")
+local idrest  = P("_") + R("AZ", "az", "09")
+local possiblename = idstart * idrest^0
+
+local keywords = {
+    "and", "break", "do", "else", "elseif", "end", "for", "false",
+    "function", "goto", "if", "in", "local", "nil", "not", "or",
+    "repeat", "return", "then", "true", "until", "while",
+}
+
+for _, keyword in ipairs(keywords) do
+    lexer[keyword:upper()] = P(keyword) * -idrest
+end
+
+local is_keyword = {}
+for _, keyword in ipairs(keywords) do
+    is_keyword[keyword] = true
+end
+
+lexer.NAME = Cmt(C(possiblename), function(_, pos, s)
+    if not is_keyword[s] then
+        return pos, s
+    else
+        return false
+    end
+end)
+
+--
+-- Symbolic tokens
+--
+
+local symbols = {
+    -- Lua:
+    ADD  = "+",  SUB   = "-",  MUL = "*", MOD = "%",
+    DIV  = "/",  IDIV  = "//", POW = "^", LEN = "#",
+    BAND = "&",  BXOR  = "~",  BOR = "|",
+    SHL  = "<<", SHR   = ">>", CONCAT = "..",
+    EQ = "==", LT = "<",  GT = ">",
+    NE = "~=", LE = "<=", GE = ">=",
+    ASSIGN = "=",
+    LPAREN   = "(", RPAREN   = ")",
+    LBRACKET = "[", RBRACKET = "]",
+    LCURLY   = "{", RCURLY   = "}",
+    SEMICOLON = ";", COMMA = ",", 
+    DOT = ".", DOTS = "...", DBLCOLON = "::", 
+    -- Titan:
+    COLON = ":",
+}
+
+for tokname, symbol in pairs(symbols) do
+    local pat = P(symbol)
+    for _ , symbol2 in pairs(symbols) do
+        if #symbol < #symbol2 and symbol == string.sub(symbol2, 1, #symbol) then
+            pat = pat - P(symbol2)
+        end
+    end
+    lexer[tokname] = pat
+end
+
+-- Additional conflicts
+lexer.DOT      = lexer.DOT      - (P(".") * R("09"))
+lexer.LBRACKET = lexer.LBRACKET - longstring_open
+lexer.SUB      = lexer.SUB      - comment_start
+
+return lexer

--- a/titan-compiler/parser.lua
+++ b/titan-compiler/parser.lua
@@ -199,7 +199,7 @@ local function errorstostr(errors)
 end
 
 function parser.parse(input)
-	local result, errors = pg.parse(input, grammar)
+    local result, errors = pg.parse(input, grammar)
     if not result then
         return false, errorstostr(errors)
     else


### PR DESCRIPTION
I split the lexer into a separate module and wrote a test suite for it with busted. The big change here is that the lexer obeys the "longest match" rule: for example, the pattern for "<" won't match "<=" and the pattern for "local" won't match "localx = 10". This is done adding appropriate negative lookaheads to the patterns.

I still need to figure out how to report lexing (and parsing) errors. I would like have the lexer report errors for invalid numbers, unclosed strings, and so on without silently backtracking but I don't know what is the best way to do it. Raise a Lua `error`? Use lpeglabel error labels? Something else?

----

I also have a few other questions:

* if we go for the `error` route, how can I catch the lexer and parser errors and reraise any other errors? I forgot if there is a way to do this with pcall.

* Last time we closed the pull request with a "merge". Perhaps we should use "rebase and merge" to keep a cleaner history in the master branch?