### PR TITLE
Add proper exception handling

### DIFF
--- a/spec/exception_spec.lua
+++ b/spec/exception_spec.lua
@@ -1,0 +1,40 @@
+local exception = require 'titan-compiler.exception'
+
+describe("Titan exception", function()
+
+    it("can print an exception", function()
+        local ex = exception.new("MyException", "error message")
+        assert.are.same(tostring(ex), "error message")
+    end)
+
+    it("can try", function()
+        local ok, err = exception.try(function()
+            return "magic"
+        end)
+        assert.are.same(ok, true)
+        assert.are.same(err, "magic")
+    end)
+
+    it("can throw an exception", function()
+        local ok, err = exception.try(function()
+            exception.throw("MyException", "error message")
+        end)
+        assert.are.same(ok, false)
+        assert.are.same(tostring(err), "error message")
+    end)
+
+    it("can rethrow an exception", function()
+        local ok, err = exception.try(function()
+            local ok, err = exception.try(function()
+                exception.throw("MyException", "error message")
+            end)
+            if not ok then
+                exception.rethrow(err)
+            else
+                return err
+            end
+        end)
+        assert.are.same(ok, false)
+        assert.are.same(tostring(err), "error message")
+    end)
+end)

--- a/titan-compiler/exception.lua
+++ b/titan-compiler/exception.lua
@@ -1,0 +1,42 @@
+--
+-- Exception handling
+
+local exception = {}
+
+local exceptionmt = {
+    __tostring = function(exception)
+        if exception.traceback then
+            return exception.msg .. exception.traceback
+        else
+            return exception.msg
+        end
+    end
+}
+
+function exception.new(tag, msg, traceback)
+    return setmetatable({tag=tag, msg=msg, traceback=traceback}, exceptionmt)
+end
+
+function exception.throw(tag, msg)
+    error(exception.new(tag, msg), 2)
+end
+
+function exception.rethrow(exc)
+    error(exc)
+end
+
+local function errhandler(err)
+    if getmetatable(err) ~= exceptionmt then
+        return exception.new('Error', err, debug.traceback('', 3))
+    else
+        return err
+    end
+end
+
+-- Execute a function with protection (like pcall), but if an error occurs
+-- always return an exception
+function exception.try(block)
+    return xpcall(block, errhandler)
+end
+
+return exception

--- a/titan-compiler/parser.lua
+++ b/titan-compiler/parser.lua
@@ -3,6 +3,7 @@ local parser = {}
 local pg = require 'parser-gen'
 local peg = require 'peg-parser'
 local ast = require 'titan-compiler.ast'
+local exception = require 'titan-compiler.exception'
 
 -- Functions used by the PEG grammar
 local defs = {}
@@ -201,7 +202,7 @@ end
 function parser.parse(input)
     local result, errors = pg.parse(input, grammar)
     if not result then
-        return false, errorstostr(errors)
+        exception.throw('ParserErr', errorstostr(errors))
     else
         return result
     end

--- a/titanc
+++ b/titanc
@@ -2,10 +2,10 @@
 
 local inspect = require 'inspect'
 local argparse = require 'argparse'
-
+local exception = require 'titan-compiler.exception'
 local parser = require 'titan-compiler.parser'
 
-local p = argparse('titan', 'Titan compiler')
+local p = argparse(arg[0], 'Titan compiler')
 p:argument('input', 'Input file.')
 p:flag('--print-ast', 'Print the AST.')
 local args = p:parse()
@@ -17,24 +17,21 @@ local function get_contents(filename)
     return contents
 end
 
--- Work like assert, but don't print the stack trace
-local function check(value, msg)
-    if not value then
-        print(msg)
-        os.exit(1)
+local function main()
+    local input
+    if args.input == '-' then
+        input = io.read("*a")
     else
-        return value
+        input = get_contents(args.input)
+    end
+    local ast = parser.parse(input)
+    if args.print_ast then
+        print(inspect(ast))
     end
 end
 
-local input
-if args.input == '-' then
-    input = io.read("*a")
-else
-    input = get_contents(args.input)
-end
-local ast = check(parser.parse(input))
-if args.print_ast then
-    print(inspect(ast))
+local ok, err = exception.try(main)
+if not ok then
+    print(arg[0] .. ': ' .. tostring(err))
 end
 


### PR DESCRIPTION
Now we are able to use `error/assert` to internal errors and `exception.throw` to expected errors.
PS: this is just the basic idea, we can implement a catch/finally latter.