### PR TITLE
Implement parser and syntax errors

### DIFF
--- a/spec/parser_spec.lua
+++ b/spec/parser_spec.lua
@@ -31,7 +31,13 @@ local function assert_ast(program, expected)
 end
 
 describe("Titan parser", function()
-    
+
+    it("can parse empty files with just whitespace and comments", function()
+        local program, err = parse_file("./testfiles/just_spaces.titan")
+        assert.truthy(program)
+        assert_ast(program, {})
+    end)
+
     it("can parse toplevel var declarations", function()
         local program, err = parse_file("./testfiles/toplevel_var.titan")
         assert.truthy(program)

--- a/spec/parser_spec.lua
+++ b/spec/parser_spec.lua
@@ -200,11 +200,17 @@ describe("Titan parser", function()
     end)
 
     it("return statements must be the last in the block", function()
-        pending("implement syntax errors")
+        local program, err =
+            parse_file("./testfiles/return_statement_not_last.titan")
+        assert.falsy(program)
+        assert.are.same("SyntaxError", err.label)
     end)
 
     it("does not allow extra semicolons after a return", function()
-        pending("implement syntax errors")
+        local program, err =
+            parse_file("./testfiles/return_statements_extra_semicolons.titan")
+        assert.falsy(program)
+        assert.are.same("SyntaxError", err.label)
     end)
 
     it("can parse binary and unary operators", function()
@@ -299,9 +305,10 @@ describe("Titan parser", function()
     end)
 
     it("only allows call expressions as statements", function()
-        pending("implement syntax errors")
-        -- 10
-        -- x[1]
+        local program, err =
+            parse_file("./testfiles/non_call_expression_statement.titan")
+        assert.falsy(program)
+        assert.are.same("SyntaxError", err.label)
     end)
 
     it("can parse calls without parenthesis", function()

--- a/testfiles/just_spaces.titan
+++ b/testfiles/just_spaces.titan
@@ -1,0 +1,5 @@
+-- When writing lpeg parsers it is easy to forget about
+-- comments and whitespace at the *start* of the file
+
+
+-- Blablabla

--- a/testfiles/non_call_expression_statement.titan
+++ b/testfiles/non_call_expression_statement.titan
@@ -1,0 +1,4 @@
+-- This should be a syntax error
+function f()
+    17
+end

--- a/testfiles/return_statement_not_last.titan
+++ b/testfiles/return_statement_not_last.titan
@@ -1,0 +1,4 @@
+function f(): nil
+    return 10
+    return 11
+end

--- a/testfiles/return_statements_extra_semicolons.titan
+++ b/testfiles/return_statements_extra_semicolons.titan
@@ -1,0 +1,3 @@
+function f1(): nil
+    return ;;
+end

--- a/titan-compiler/syntax_errors.lua
+++ b/titan-compiler/syntax_errors.lua
@@ -1,0 +1,50 @@
+local syntax_errors = {}
+
+local errors = {
+    -- The `0` label is the default "parsing failed" error number
+    [0] = {
+      label = "SyntaxError",
+        msg = "Syntax Error" },
+
+    { label = "MalformedNumber",
+        msg = "Malformed number" },
+
+    { label = "UnclosedLongString",
+        msg = "Unclosed long string or long comment" },
+
+    { label = "UnclosedShortString",
+        msg = "Unclosed short string" },
+
+    { label = "InvalidEscape",
+        msg = "Invalid escape character in string" },
+
+    { label = "UnimplementedEscape_ddd",
+        msg = "\\ddd escape sequences have not been implemented yet."  },
+
+    { label = "UnimplementedEscape_u",
+        msg = "\\u escape sequences have not been implemented yet." },
+
+    { label = "UnimplementedEscape_x",
+        msg = "\\x escape sequences have not been implemented yet." },
+
+    { label = "UnimplementedEscape_a",
+        msg = "\\z escape sequences have not been implemented yet." },
+}
+
+syntax_errors.label_to_msg = {}
+syntax_errors.label_to_int = {}
+syntax_errors.int_to_label = {}
+syntax_errors.int_to_msg   = {}
+
+do
+    for i, t in pairs(errors) do
+        local label = assert(t.label)
+        local msg   = assert(t.msg)
+        syntax_errors.label_to_msg[label] = msg
+        syntax_errors.label_to_int[label] = i
+        syntax_errors.int_to_label[i] = label
+        syntax_errors.int_to_msg[i] = msg
+    end
+end
+
+return syntax_errors

--- a/titanc
+++ b/titanc
@@ -12,24 +12,26 @@ p:flag('--print-ast', 'Print the AST.')
 local args = p:parse()
 
 -- Work like assert, but don't print the stack trace
-local function check(value, msg)
-    if not value then
-        print(arg[0] .. ": " .. tostring(msg))
-        os.exit(1)
-    else
-        return value
-    end
+local function exit(msg)
+    io.stderr:write(arg[0], ": ", msg, "\n")
+    os.exit(1)
 end
 
-local input
+local input, err
 if args.input == '-' then
     input = io.read("*a")
 else
-    input = check(util.get_file_contents(args.input))
+    input, errmsg = util.get_file_contents(args.input)
+    if not input then exit(errmsg) end
 end
-local ast = check(parser.parse(input))
+
+local ast, err = parser.parse(input)
+if not ast then exit(parser.error_to_string(err)) end
+
 if args.print_ast then
     print(parser.pretty_print_ast(ast))
 end
-check(checker.check(ast))
+
+local ok, errmsg = checker.check(ast)
+if not ok then exit(errsmg) end
 


### PR DESCRIPTION
I'm not super happy about the current state of this code because I felt like I was fighting against parser-gen's and lpeglabel's APIs to get them to work with each other. In particular:

* The API for setting error labels in those two libraries is incompatible, so it is hard to use an lpeglabel lexer inside a parser-gen parser. If only lpeglabel allowed arbitrary Lua values as labels...
* I'm not sure I really understand how the "%" (subparser) operator works in parser-gen. From the experiments I made, it seemed that the SKIP and error recovery from the subparser can leak into the parent parser, which is weird. The patterns that parser-gen creates also need to be executed with parser-gen.parse and will error-out if you call the match method on them so I am not sure if it is even correct to treat them as patterns.

Anyway, I'm submitting this PR so we can have a place to discuss these problems and because I wanted to get this stuff out of the way so I can can focus on the rest of the compiler for now. I guess we could wait until we figure out a more permanent solution for those lpeg and parser-gen issues before merging this.