### PR TITLE
first sketch of typechecker

### DIFF
--- a/spec/parser_spec.lua
+++ b/spec/parser_spec.lua
@@ -167,9 +167,8 @@ describe("Titan parser", function()
 
             { _tag = "Stat_Block",
                 stats = {
-                    { _tag = "Stat_Decl", decl = { name = "x" } },
-                    { _tag = "Stat_Assign",
-                        var = { name = "x" },
+                    { _tag = "Stat_Decl",
+                        decl = { name = "x" },
                         exp = { value = 10 } },
                     { _tag = "Stat_Assign",
                         var = { name = "x" },

--- a/testfiles/selection_sort.titan
+++ b/testfiles/selection_sort.titan
@@ -1,0 +1,21 @@
+function selection_sort(xs: {Integer}): Nil
+    local N: Integer = #xs
+    for i: Integer = 1, N do
+
+        -- Find minimum
+        local min_i: Integer = i
+        local min_x: Integer = xs[i]
+        for j: Integer = i+1, N do
+            local y: Integer = xs[j]
+            if y < min_x then
+                min_i = j
+                min_x = y
+            end
+        end
+
+        -- Move it to the front
+        local tmp: Integer = xs[i]
+        xs[i] = xs[min_i]
+        xs[min_i] = tmp
+    end
+end

--- a/testfiles/sieve.titan
+++ b/testfiles/sieve.titan
@@ -1,0 +1,23 @@
+function sieve(N: Integer): {Integer}
+
+    local is_prime: {Boolean} = {}
+    is_prime[1] = false
+    for n:Integer = 2, N do
+        is_prime[n] = true
+    end
+
+    local nprimes: Integer = 0
+    local primes: {Integer} = {}
+
+    for n:Integer = 1, N do
+        if is_prime[n] then
+            nprimes = nprimes + 1;
+            primes[nprimes] = n
+            for m:Integer = n+n, N, n do
+                is_prime[m] = false
+            end
+        end
+    end
+
+    return primes
+end

--- a/titan-compiler/ast.lua
+++ b/titan-compiler/ast.lua
@@ -24,7 +24,7 @@ types.Stat = {
     If      = {'thens', 'elsestat'},
     For     = {'decl', 'start', 'finish', 'inc', 'block'},
     Assign  = {'var', 'exp'},
-    Decl    = {'decl'},
+    Decl    = {'decl', 'exp'},
     Call    = {'callexp'},
     Return  = {'exp'},
 }

--- a/titan-compiler/ast.lua
+++ b/titan-compiler/ast.lua
@@ -49,6 +49,9 @@ types.Exp = {
     Var     = {'var'},
     Unop    = {'op', 'exp'},
     Binop   = {'lhs', 'op', 'rhs'},
+    ToFloat = { 'exp' },
+    ToInt   = { 'exp' },
+    ToStr   = { 'exp' }
 }
 
 types.Args = {

--- a/titan-compiler/checker.lua
+++ b/titan-compiler/checker.lua
@@ -1,54 +1,210 @@
 local checker = {}
 
 local symtab = require 'titan-compiler.symtab'
+local types = require 'titan-compiler.types'
 
-local function visit_children(f, node, ...)
-    local tag = node._tag
-    if not tag then -- the node is an array
-        for _, child in ipairs(node) do
-            f(child, ...)
-        end
+local typecheck
+
+local function typefromnode(typenode, errors)
+    local tag = typenode._tag
+    if tag == "Array" then
+        return types.Array(typefromnode(typenode.subtype, errors))
     else
-        for _, child in node:children() do
-            f(child, ...)
+        local t = types.Base(typenode.name)
+        if not t then
+            table.insert(errors, "type name " .. typenode.name .. " is invalid")
+            t = types.Integer
+        end
+        return t
+    end
+end
+
+local function firstpass(ast, st, errors)
+    for _, tlnode in ipairs(ast) do
+        local tag = tlnode._tag
+        local name
+        if tag == "TopLevel_Func" then
+            name = tlnode.name
+            local ptypes = {}
+            for _, pdecl in tlnode.params do
+                table.insert(ptypes, typefromnode(pdecl.type, errors))
+            end
+            tlnode._type = types.Function(ptypes, typefromnode(tlnode.rettype, errors))
+        else
+            assert(tag == "TopLevel_Var")
+            name = tlnode.decl.name
+            tlnode._type = typefromnode(tlnode.decl.type, errors)
+        end
+        if st:find_dup(name) then
+            table.insert(errors, "duplicate function or variable declaration for " .. name)
+            tlnode.ignore = true
+        else
+            st:add_symbol(name, tlnode)
         end
     end
 end
 
-local function bindvars(node, st, errors)
-    if not node or type(node) ~= "table" then
-        return
+local function checkmatch(term, expected, found, errors)
+    if not types.equals(expected, found) then
+        local msg = "types in %s do not match, expected %s but found %s"
+        table.insert(errors, string.format(msg, term, types.tostring(expected), types.tostring(found)))
     end
+end
 
+local function checkrepeat(node, st, errors)
+    for _, stat in ipairs(node.block.stats) do
+        typecheck(stat, st, errors)
+    end
+    typecheck(node.condition, st, errors)
+end
+
+local function checkfor(node, st, errors)
+    typecheck(node.decl, st, errors)
+    local ftype = node.decl._type
+    if not types.equals(ftype, types.Integer) and
+        not types.equals(ftype, types.Float) then
+        table.insert(errors, "type of for control variable " .. node.decl.name .. " must be integer or float")
+        node.decl._type = types.Integer
+        ftype = types.Integer
+    end
+    typecheck(node.start, st, errors)
+    checkmatch("'for' start expression", ftype, node.start._type, errors)
+    typecheck(node.finish, st, errors)
+    checkmatch("'for' finish expression", ftype, node.finish._type, errors)
+    if node.inc then
+        typecheck(node.inc, st, errors)
+        checkmatch("'for' step expression", ftype, node.inc._type, errors)
+    end
+    typecheck(node.block, st, errors)
+end
+
+local function checkblock(node, st, errors)
+    for _, stat in node.stats do
+        typecheck(stat, st, errors)
+    end
+end
+
+function typecheck(node, st, errors)
     local tag = node._tag
-    if tag == "TopLevel_Func" then
+    if tag == "Decl_Decl" then
         st:add_symbol(node.name, node)
-        st:with_block(visit_children, node, st, errors)
-
-    elseif tag == "Decl_Decl" then
-        st:add_symbol(node.name, node)
-
-    elseif tag == "Stat_Block" or
-           tag == "Stat_For" then
-        st:with_block(visit_children, node, st, errors)
-
+        node._type = typefromnode(node.type, errors)
+    elseif tag == "Stat_Decl" then
+        typecheck(node.exp, st, errors)
+        typecheck(node.decl, st, errors)
+        checkmatch("declaration of local variable " .. node.decl.name,
+            node.decl._type, node.exp._type, errors)
+    elseif tag == "Stat_Block" then
+        st:with_block(checkblock, node, st, errors)
+    elseif tag == "Stat_While" then
+        typecheck(node.condition, st, errors)
+        st:with_block(typecheck, node.block, st, errors)
+    elseif tag == "Stat_Repeat" then
+        st:with_block(checkrepeat, node, st, errors)
+    elseif tag == "Stat_For" then
+        st:with_block(checkfor, node, st, errors)
+    elseif tag == "Stat_Assign" then
+        typecheck(node.var, st, errors)
+        typecheck(node.exp, st, errors)
+        checkmatch("assignment", node.var._type, node.exp._type, errors)
+    elseif tag == "Stat_Call" then
+        typecheck(node.callexp, st, errors)
+    elseif tag == "Stat_Return" then
+        typecheck(node.exp, st, errors)
+        checkmatch("return", st:find_symbol("$function")._type.ret, node.exp_type, errors)
+    elseif tag == "Stat_If" then
+        for _, thn in ipairs(node.thens) do
+            typecheck(thn.condition, st, errors)
+            typecheck(thn.block, st, errors)
+        end
+        if node.elsestat then typecheck(node.elsestat, st, errors) end
     elseif tag == "Var_Name" then
-        node.decl = st:find_symbol(node.name)
-        if not node.decl then
+        local decl = st:find_symbol(node.name) 
+        if not decl then
             -- TODO generate better error messages when we have the line num
             local error = "variable '" .. node.name .. "' not declared"
             table.insert(errors, error)
+            node._type = types.Integer
+        elseif decl._tag == "TopLevel_Func" then
+            table.insert(errors, "reference to function " .. node.name .. " outside of function call")
+            node._type = types.Integer
+        else
+            node.decl = decl
+            node._type = decl._type
         end
-
+    elseif tag == "Var_Index" then
+        typecheck(node.exp1, st, errors)
+        if not types.has_tag(node.exp1._type, "Array") then
+            table.insert(errors, "array expression in indexing is not an array but " 
+                .. types.tostring(node.exp1._type))
+            node._type = types.Integer
+        else
+            node._type = node.exp1._type.elem
+        end
+        typecheck(node.exp2, st, errors)
+        checkmatch("array indexing", types.Integer, node.exp2._type, errors)
+    elseif tag == "Exp_Nil" then
+        node._type = types.Nil
+    elseif tag == "Exp_Bool" then
+        node._type = types.Boolean
+    elseif tag == "Exp_Integer" then
+        node._type = types.Integer
+    elseif tag == "Exp_Float" then
+        node._type = types.Float
+    elseif tag == "Exp_String" then
+        node._type = types.String
+    elseif tag == "Exp_Table" then
+        local etypes = {}
+        for _, exp in ipairs(node.exps) do
+            typecheck(exp, st, errors)
+            table.insert(etypes, exp._type)
+        end
+        local etype = etypes[1] or types.Integer
+        node._type = types.Array(etype)
+        for i, exp in ipairs(node.exps) do
+            checkmatch("array initializer at position " .. i, etype, exp._type)
+        end
+    elseif tag == "Exp_Var" then
+        typecheck(node.var, st, errors)
+        node._type = node.var._type
+    elseif tag == "Exp_Unop" then
+        -- TODO: check kind of operation, maybe have different kinds of AST nodes?
+    elseif tag == "Exp_Binop" then
+        -- TODO: same here, separate AST nodes by kind of binary operation
+    elseif tag == "Exp_Call" then
+        -- TODO: lookup function, check args, _type is return type
     else
-        visit_children(node, st, errors)
+        error("typechecking not implemented for node type " .. tag)
+    end
+end
+
+local function checkfunc(node, st, errors)
+    st:add_symbol("$function", node) -- for return type
+    for _, param in node.params do
+        typecheck(param, st, errors)
+    end
+    -- TODO: check if all paths through the function have returned
+    st:with_block(typecheck, node.block, st, errors)
+end
+
+local function secondpass(ast, st, errors)
+    for _, tlnode in ipairs(ast) do
+        if not tlnode.ignore then
+            local tag = tlnode._tag
+            if tag == "TopLevel_Func" then
+                st:with_block(checkfunc, node, st, errors)
+            else
+                typecheck(tlnode.value, st, errors)
+            end
+        end
     end
 end
 
 function checker.check(ast)
     local st = symtab.new()
     local errors = {}
-    st:with_block(bindvars, ast, st, errors)
+    st:with_block(firstpass, ast, st, errors)
+    st:with_block(secondpass, ast, st, errors)
     -- TODO return all error messages
     if #errors > 0 then
         return false, errors[1]

--- a/titan-compiler/parser.lua
+++ b/titan-compiler/parser.lua
@@ -68,9 +68,8 @@ function defs.ifstat(exp, block, thens, elseopt)
 end
 
 function defs.defstat(decl, exp)
-    local declstat = ast.Stat_Decl(decl)
-    local assign = ast.Stat_Assign(ast.Var_Name(decl.name), exp)
-    return declstat, assign
+    local declstat = ast.Stat_Decl(decl, exp)
+    return declstat
 end
 
 function defs.fold_binop_left(matches)

--- a/titan-compiler/symtab.lua
+++ b/titan-compiler/symtab.lua
@@ -18,8 +18,9 @@ end
 
 function symtab:with_block(body, ...)
     self:open_block()
-    body(...)
-    return self:close_block()
+    local res = body(...)
+    self:close_block()
+    return res
 end
 
 function symtab:add_symbol(name, decl)

--- a/titan-compiler/symtab.lua
+++ b/titan-compiler/symtab.lua
@@ -11,13 +11,15 @@ function symtab:open_block()
 end
 
 function symtab:close_block()
+    local last = self.blocks[#self.blocks]
     table.remove(self.blocks)
+    return last
 end
 
 function symtab:with_block(body, ...)
     self:open_block()
     body(...)
-    self:close_block()
+    return self:close_block()
 end
 
 function symtab:add_symbol(name, decl)
@@ -35,6 +37,10 @@ function symtab:find_symbol(name)
         end
     end
     return decl
+end
+
+function symtab:find_dup(name)
+    return self.blocks[#self.blocks][name]
 end
 
 return symtab

--- a/titan-compiler/types.lua
+++ b/titan-compiler/types.lua
@@ -1,0 +1,56 @@
+
+local types = {}
+
+function types.Function(ptypes, rettype)
+    return { _tag = "Function", params = ptypes, ret = rettype }
+end
+
+function types.Array(etype)
+    return { _tag = "Array", elem = etype }
+end
+
+local base_types = { "Integer", "Boolean", "String", "Nil", "Float" }
+
+for _, t in ipairs(base_types) do
+    types[t] = { _tag = t }
+    base_types[t] = types[t]
+end
+
+function types.Base(name)
+    return base_types[name]
+end
+
+function types.has_tag(t, name)
+    return t._tag == name
+end
+
+function types.equals(t1, t2)
+    local tag1, tag2 = t1._tag, t2._tag
+    if tag1 == "Array" and tag2 == "Array" then
+        return types.equals(t1.elem, t2.elem)
+    elseif tag1 == "Function" and tag2 == "Function" then
+        if types.equals(t1.ret, t2.ret) and (#t1.params == #t2.params) then
+            for i = 1, #t1.params do
+                if not types.equals(t1.params[i], t2.params[i]) then
+                    return false
+                end
+            end
+            return true
+        end
+    else
+        return tag1 == tag2
+    end
+    return false
+end
+
+function types.tostring(t)
+    local tag = t._tag
+    if tag == "Array" then
+        return "{ " .. types.tostring(t.elem) .. " }"
+    elseif tag == "Function" then
+    else
+        return string.lower(tag)
+    end
+end
+
+return types

--- a/titanc
+++ b/titanc
@@ -9,6 +9,7 @@ local util = require 'titan-compiler.util'
 local p = argparse('titan', 'Titan compiler')
 p:argument('input', 'Input file.')
 p:flag('--print-ast', 'Print the AST.')
+p:flag('--print-types', 'Print the AST with types.')
 local args = p:parse()
 
 -- Work like assert, but don't print the stack trace
@@ -30,8 +31,13 @@ if not ast then exit(parser.error_to_string(err)) end
 
 if args.print_ast then
     print(parser.pretty_print_ast(ast))
+    os.exit(0)
 end
 
-local ok, errmsg = checker.check(ast)
-if not ok then exit(errsmg) end
+local ok, errmsgs = checker.check(ast)
+if not ok then exit( errmsgs[1] ) end
 
+if args.print_types then
+    print(parser.pretty_print_ast(ast))
+    os.exit(0)
+end


### PR DESCRIPTION
This pull request is not meant for merging, just for reviewing and discussion. I have made a first sketch of the typechecker. Major parts missing are checks for unary and binary operations, for integer->float coercions on assignment, for function calls, and for making sure all paths through a function either return or the function has a nil return type.

The typechecker works in two passes, the first one just collects type information for top-level functions and variables (and detects duplicate definitions in the top level), while the second pass does the actual typechecking. All typechecked nodes that have a type get a "_type" field with the type. The types themselves are in "types.lua".
