### PR TITLE
Adding coverage results and other small things

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -64,8 +64,7 @@ script:
   - busted -c -o gtest -v spec/
 
 #after_success:
-#  - luacov -c $TRAVIS_BUILD_DIR/test/luacov.config
-#  - cd $TRAVIS_BUILD_DIR/test/ && bash <(curl -s https://codecov.io/bash)
+   - luacov && bash <(curl -s https://codecov.io/bash)
 
 notifications:
   email:

--- a/.travis.yml
+++ b/.travis.yml
@@ -64,7 +64,7 @@ script:
   - busted -c -o gtest -v spec/
 
 #after_success:
-   - luacov && bash <(curl -s https://codecov.io/bash)
+  - luacov && bash <(curl -s https://codecov.io/bash)
 
 notifications:
   email:

--- a/README.md
+++ b/README.md
@@ -1,0 +1,38 @@
+# Titan
+[![Build Status](https://travis-ci.org/titan-lang/titan-v0.svg?branch=master)](https://travis-ci.org/titan-lang/titan-v0)
+[![Coverage Status](https://codecov.io/gh/titan-lang/titan-v0/coverage.svg?branch=master)](https://codecov.io/gh/titan-lang/titan-v0/branch/master)
+
+Titan is a programming language, based on the syntax and semantics of
+[Lua](http://www.lua.org), to be a statically-typed, ahead-of-time compiled
+sister language to Lua. Converting Lua code to Titan should yield a
+significant speedup, in some cases approaching the speed of C code.
+
+The Titan compiler is under development and it is compiling Titan modules
+to C code in the [artisanal style](https://github.com/titan-lang/artisanal-titan).
+For more information, please, see the [reference manual](https://github.com/titan-lang/titan-lang-docs/blob/master/manual.md).
+
+# Requirements for running the compiler
+
+1. [Lua](http://www.lua.org/) >= 5.3.0
+2. [LPegLabel](https://github.com/sqmedeiros/lpeglabel) >= 1.0.0
+3. [inspect](https://github.com/kikito/inspect.lua) >= 3.1.0
+4. [argparse](https://github.com/mpeterv/argparse) >= 0.5.0
+
+# Install
+
+Titan must be installed in a standard location;
+[LuaRocks](http://luarocks.org) will do this, and will also install all dependencies automatically.
+
+        $ [install luarocks]
+        $ luarocks install titan-lang-scm-1.rockspec
+
+# Usage
+
+        $ titanc [options] <input>
+
+# Compiler options
+
+        --print-ast                     Print the AST.
+        --print-types                   Print the AST with types.
+        -o <output>, --output <output>  Output file.
+        -h, --help                      Show this help message and exit.

--- a/titan-v0-scm-1.rockspec
+++ b/titan-v0-scm-1.rockspec
@@ -15,7 +15,7 @@ description = {
 }
 dependencies = {
    "lua ~> 5.3",
-   "parser-gen >= 1.0",
+   "lpeglabel >= 1.0.0",
    "inspect >= 3.1.0",
    "argparse >= 0.5.0",
 }
@@ -23,8 +23,12 @@ build = {
    type = "builtin",
    modules = {
       ["titan-compiler.ast"] = "titan-compiler/ast.lua",
+      ["titan-compiler.checker"] = "titan-compiler/checker.lua",
       ["titan-compiler.lexer"] = "titan-compiler/lexer.lua",
       ["titan-compiler.parser"] = "titan-compiler/parser.lua"
+      ["titan-compiler.symtab"] = "titan-compiler/symtab.lua"
+      ["titan-compiler.syntax_errors"] = "titan-compiler/syntax_errors.lua"
+      ["titan-compiler.util"] = "titan-compiler/util.lua"
    },
    install = {
       bin = {

--- a/titan-v0-scm-1.rockspec
+++ b/titan-v0-scm-1.rockspec
@@ -25,10 +25,10 @@ build = {
       ["titan-compiler.ast"] = "titan-compiler/ast.lua",
       ["titan-compiler.checker"] = "titan-compiler/checker.lua",
       ["titan-compiler.lexer"] = "titan-compiler/lexer.lua",
-      ["titan-compiler.parser"] = "titan-compiler/parser.lua"
-      ["titan-compiler.symtab"] = "titan-compiler/symtab.lua"
-      ["titan-compiler.syntax_errors"] = "titan-compiler/syntax_errors.lua"
-      ["titan-compiler.util"] = "titan-compiler/util.lua"
+      ["titan-compiler.parser"] = "titan-compiler/parser.lua",
+      ["titan-compiler.symtab"] = "titan-compiler/symtab.lua",
+      ["titan-compiler.syntax_errors"] = "titan-compiler/syntax_errors.lua",
+      ["titan-compiler.util"] = "titan-compiler/util.lua",
    },
    install = {
       bin = {


### PR DESCRIPTION
This PR adds coverage results with `codecov` to our repository. It also includes a `README.md` that shows test and coverage results. Finally, it fixes the rockspec to depend on `lpeglabel` instead of `parser-gen` and to install the new modules that we have at this moment.