### PR TITLE
`for-in` construct

### DIFF
--- a/spec/parser_spec.lua
+++ b/spec/parser_spec.lua
@@ -194,8 +194,7 @@ describe("Titan parser", function()
                     exp = { var = { _tag = "Var_Name", name = "i" } },
                     var = { _tag = "Var_Name", name = "i" } } } },
               decl = { _tag = "Decl_Decl", name = "i", type = false },
-              exp = { _tag = "Stat_Call",
-                      callexp = { _tag = "Exp_Call" } } },
+              exp = { _tag = "Exp_Call" } },
 
             { _tag = "Stat_Return", exp = { _tag = "Exp_Var" } },
         })

--- a/spec/parser_spec.lua
+++ b/spec/parser_spec.lua
@@ -187,6 +187,16 @@ describe("Titan parser", function()
               inc =    { _tag = "Exp_Integer", value = 3 },
               start =  { _tag = "Exp_Integer", value = 1 } },
 
+            { _tag = "Stat_ForIn",
+              block = {
+                stats = {
+                  { _tag = "Stat_Assign",
+                    exp = { var = { _tag = "Var_Name", name = "i" } },
+                    var = { _tag = "Var_Name", name = "i" } } } },
+              decl = { _tag = "Decl_Decl", name = "i", type = false },
+              exp = { _tag = "Stat_Call",
+                      callexp = { _tag = "Exp_Call" } } },
+
             { _tag = "Stat_Return", exp = { _tag = "Exp_Var" } },
         })
     end)

--- a/testfiles/statements.titan
+++ b/testfiles/statements.titan
@@ -18,7 +18,7 @@ local function statements(): nil
         i = i
     end
 
-    for i in each() do
+    for i in pairs(t) do
         i = i
     end
 

--- a/testfiles/statements.titan
+++ b/testfiles/statements.titan
@@ -18,5 +18,9 @@ local function statements(): nil
         i = i
     end
 
+    for i in each() do
+        i = i
+    end
+
     return x
 end

--- a/titan-compiler/ast.lua
+++ b/titan-compiler/ast.lua
@@ -23,6 +23,7 @@ types.Stat = {
     Repeat  = {"block", "condition"},
     If      = {"thens", "elsestat"},
     For     = {"decl", "start", "finish", "inc", "block"},
+    ForIn   = {"decl", "exp", "block"},
     Assign  = {"var", "exp"},
     Decl    = {"decl", "exp"},
     Call    = {"callexp"},

--- a/titan-compiler/checker.lua
+++ b/titan-compiler/checker.lua
@@ -232,6 +232,24 @@ local function checkfor(node, st, errors)
     return false
 end
 
+-- Typechecks a for-in statement
+--   node: Stat_For AST node
+--   st: symbol table
+--   errors: list of compile-time errors
+--   returns whether statement always returns from its function (always false for 'for' loop)
+local function checkforin(node, st, errors)
+    checkstat(node.decl, st, errors)
+    checkexp(node.exp, st, errors)
+    if node.decl.type then
+        checkstat(node.decl, st, errors)
+        local dtype = node.decl._type
+        node.exp = trycoerce(node.exp, dtype)
+        checkmatch("'for' expression", dtype, node.exp._type, errors, node.exp._pos)
+    end
+    checkstat(node.block, st, errors)
+    return false
+end
+
 -- Typechecks a block statement
 --   node: Stat_Block AST node
 --   st: symbol table
@@ -276,6 +294,8 @@ function checkstat(node, st, errors)
         st:with_block(checkrepeat, node, st, errors)
     elseif tag == "Stat_For" then
         st:with_block(checkfor, node, st, errors)
+    elseif tag == "Stat_ForIn" then
+        st:with_block(checkforin, node, st, errors)
     elseif tag == "Stat_Assign" then
         checkexp(node.var, st, errors)
         -- mark this variable as assigned to

--- a/titan-compiler/parser.lua
+++ b/titan-compiler/parser.lua
@@ -202,6 +202,9 @@ local grammar = re.compile([[
                            ASSIGN exp COMMA exp
                            (COMMA exp)? -> opt
                            DO block END)                    -> Stat_For
+                     / ({} FOR decl
+                           IN exp
+                           DO block END)                    -> Stat_ForIn
                      / ({} LOCAL decl ASSIGN exp)           -> defstat
                      / ({} var ASSIGN exp)                  -> Stat_Assign
                      / ({} (suffixedexp => exp_is_call))    -> Stat_Call


### PR DESCRIPTION
Just pushed to the server some code I had lying around when I started playing with adding `for-in`. So far it has just the parser update and beginnings of type checking.

Evidently this needs to wait until we have other features in place for the complete functionality of `for-in` to work (first class functions being the most obvious one) unless we want to support a hacky version first with hardcoded support for the standard library iterators only (which I see as being special-cased in the code-generator anyway, so it's not like that would be throwaway code).
