### PR TITLE
marking a variable as assigned only if it was declared

### DIFF
--- a/titan-compiler/checker.lua
+++ b/titan-compiler/checker.lua
@@ -278,9 +278,9 @@ function checkstat(node, st, errors)
         st:with_block(checkfor, node, st, errors)
     elseif tag == "Stat_Assign" then
         checkexp(node.var, st, errors)
-        -- mark this variable as assigned to
-        if node.var._tag == "Var_Name" then
-          node.var._decl._assigned = true
+        -- mark this declared variable as assigned to
+        if node.var._tag == "Var_Name" and node.var._decl then
+            node.var._decl._assigned = true
         end
         checkexp(node.exp, st, errors, node.var._type)
         node.exp = trycoerce(node.exp, node.var._type)


### PR DESCRIPTION
The following test case makes the Titan compiler crash:
```lua
function fn(): nil
    local x: integer = 1
    y = 2
end
```
This PR fixes this problem and it is necessary for two test cases that are failing on PR #46. One of these test cases is the above example.