### PR TITLE
allowing relational expressions for comparing strings

### DIFF
--- a/spec/checker_spec.lua
+++ b/spec/checker_spec.lua
@@ -531,5 +531,256 @@ describe("Titan type checker", function()
         local ok, err = run_checker(code)
         assert.truthy(ok)
     end)
+
+    for _, op in ipairs({"==", "~="}) do
+        it("can compare arrays of same type using " .. op, function()
+            local code = [[
+                function fn(a1: {integer}, a2: {integer}): boolean
+                    return a1 ]] .. op .. [[ a2
+                end
+            ]]
+            local ast, err = parser.parse(code)
+            local ok, err = checker.check(ast, code, "test.titan")
+            assert.truthy(ok)
+        end)
+    end
+
+    for _, op in ipairs({"==", "~="}) do
+        it("can compare booleans using " .. op, function()
+            local code = [[
+                function fn(b1: string, b2: string): boolean
+                    return b1 ]] .. op .. [[ b2
+                end
+            ]]
+            local ast, err = parser.parse(code)
+            local ok, err = checker.check(ast, code, "test.titan")
+            assert.truthy(ok)
+        end)
+    end
+
+    for _, op in ipairs({"==", "~=", "<", ">", "<=", ">="}) do
+        it("can compare floats using " .. op, function()
+            local code = [[
+                function fn(f1: string, f2: string): boolean
+                    return f1 ]] .. op .. [[ f2
+                end
+            ]]
+            local ast, err = parser.parse(code)
+            local ok, err = checker.check(ast, code, "test.titan")
+            assert.truthy(ok)
+        end)
+    end
+
+    for _, op in ipairs({"==", "~=", "<", ">", "<=", ">="}) do
+        it("can compare integers using " .. op, function()
+            local code = [[
+                function fn(i1: string, i2: string): boolean
+                    return i1 ]] .. op .. [[ i2
+                end
+            ]]
+            local ast, err = parser.parse(code)
+            local ok, err = checker.check(ast, code, "test.titan")
+            assert.truthy(ok)
+        end)
+    end
+
+    for _, op in ipairs({"==", "~=", "<", ">", "<=", ">="}) do
+        it("can compare integers and floats using " .. op, function()
+            local code = [[
+                function fn(i: integer, f: float): boolean
+                    return i ]] .. op .. [[ f
+                end
+            ]]
+            local ast, err = parser.parse(code)
+            local ok, err = checker.check(ast, code, "test.titan")
+            assert.truthy(ok)
+        end)
+    end
+
+    for _, op in ipairs({"==", "~=", "<", ">", "<=", ">="}) do
+        it("can compare strings using " .. op, function()
+            local code = [[
+                function fn(s1: string, s2: string): boolean
+                    return s1 ]] .. op .. [[ s2
+                end
+            ]]
+            local ast, err = parser.parse(code)
+            local ok, err = checker.check(ast, code, "test.titan")
+            assert.truthy(ok)
+        end)
+    end
+
+    for _, op in ipairs({"==", "~="}) do
+        it("cannot compare arrays of different types using " .. op, function()
+            local code = [[
+                function fn(a1: {integer}, a2: {float}): boolean
+                    return a1 ]] .. op .. [[ a2
+                end
+            ]]
+            local ast, err = parser.parse(code)
+            local ok, err = checker.check(ast, code, "test.titan")
+            assert.falsy(ok)
+            assert.match("trying to compare values of different types", err)
+        end)
+    end
+
+    for _, op in ipairs({"==", "~="}) do
+        for _, t1 in ipairs({"{integer}", "boolean", "float", "string"}) do
+            for _, t2 in ipairs({"{integer}", "boolean", "float", "string"}) do
+                if t1 ~= t2 then
+                    it("cannot compare " .. t1 .. " and " .. t2 .. " using " .. op, function()
+                        local code = [[
+                            function fn(a: ]] .. t1 .. [[, b: ]] .. t2 .. [[): boolean
+                                return a ]] .. op .. [[ b
+                            end
+                        ]]
+                        local ast, err = parser.parse(code)
+                        local ok, err = checker.check(ast, code, "test.titan")
+                        assert.falsy(ok)
+                        assert.match("trying to compare values of different types", err)
+                    end)
+                end
+            end
+        end
+    end
+
+    for _, op in ipairs({"==", "~="}) do
+        for _, t1 in ipairs({"{integer}", "boolean", "integer", "string"}) do
+            for _, t2 in ipairs({"{integer}", "boolean", "integer", "string"}) do
+                if t1 ~= t2 then
+                    it("cannot compare " .. t1 .. " and " .. t2 .. " using " .. op, function()
+                        local code = [[
+                            function fn(a: ]] .. t1 .. [[, b: ]] .. t2 .. [[): boolean
+                                return a ]] .. op .. [[ b
+                            end
+                        ]]
+                        local ast, err = parser.parse(code)
+                        local ok, err = checker.check(ast, code, "test.titan")
+                        assert.falsy(ok)
+                        assert.match("trying to compare values of different types", err)
+                    end)
+                end
+            end
+        end
+    end
+
+    for _, op in ipairs({"<", ">", "<=", ">="}) do
+        for _, t in ipairs({"{integer}", "boolean", "string"}) do
+            it("cannot compare " .. t .. " and float using " .. op, function()
+                local code = [[
+                    function fn(a: ]] .. t .. [[, b: float): boolean
+                        return a ]] .. op .. [[ b
+                    end
+                ]]
+                local ast, err = parser.parse(code)
+                local ok, err = checker.check(ast, code, "test.titan")
+                assert.falsy(ok)
+                assert.match("left hand side of relational expression is", err)
+            end)
+        end
+    end
+
+    for _, op in ipairs({"<", ">", "<=", ">="}) do
+        for _, t in ipairs({"{integer}", "boolean", "string"}) do
+            it("cannot compare float and " .. t .. " using " .. op, function()
+                local code = [[
+                    function fn(a: float, b: ]] .. t .. [[): boolean
+                        return a ]] .. op .. [[ b
+                    end
+                ]]
+                local ast, err = parser.parse(code)
+                local ok, err = checker.check(ast, code, "test.titan")
+                assert.falsy(ok)
+                assert.match("right hand side of relational expression is", err)
+            end)
+        end
+    end
+
+    for _, op in ipairs({"<", ">", "<=", ">="}) do
+        for _, t in ipairs({"{integer}", "boolean", "string"}) do
+            it("cannot compare " .. t .. " and integer using " .. op, function()
+                local code = [[
+                    function fn(a: ]] .. t .. [[, b: integer): boolean
+                        return a ]] .. op .. [[ b
+                    end
+                ]]
+                local ast, err = parser.parse(code)
+                local ok, err = checker.check(ast, code, "test.titan")
+                assert.falsy(ok)
+                assert.match("left hand side of relational expression is", err)
+            end)
+        end
+    end
+
+    for _, op in ipairs({"<", ">", "<=", ">="}) do
+        for _, t in ipairs({"{integer}", "boolean", "string"}) do
+            it("cannot compare integer and " .. t .. " using " .. op, function()
+                local code = [[
+                    function fn(a: integer, b: ]] .. t .. [[): boolean
+                        return a ]] .. op .. [[ b
+                    end
+                ]]
+                local ast, err = parser.parse(code)
+                local ok, err = checker.check(ast, code, "test.titan")
+                assert.falsy(ok)
+                assert.match("right hand side of relational expression is", err)
+            end)
+        end
+    end
+
+    for _, op in ipairs({"<", ">", "<=", ">="}) do
+        for _, t in ipairs({"{integer}", "boolean"}) do
+            it("cannot compare " .. t .. " and string using " .. op, function()
+                local code = [[
+                    function fn(a: ]] .. t .. [[, b: string): boolean
+                        return a ]] .. op .. [[ b
+                    end
+                ]]
+                local ast, err = parser.parse(code)
+                local ok, err = checker.check(ast, code, "test.titan")
+                assert.falsy(ok)
+                assert.match("left hand side of relational expression is", err)
+            end)
+        end
+    end
+
+    for _, op in ipairs({"<", ">", "<=", ">="}) do
+        for _, t in ipairs({"{integer}", "boolean"}) do
+            it("cannot compare string and " .. t .. " using " .. op, function()
+                local code = [[
+                    function fn(a: string, b: ]] .. t .. [[): boolean
+                        return a ]] .. op .. [[ b
+                    end
+                ]]
+                local ast, err = parser.parse(code)
+                local ok, err = checker.check(ast, code, "test.titan")
+                assert.falsy(ok)
+                assert.match("right hand side of relational expression is", err)
+            end)
+        end
+    end
+
+    for _, op in ipairs({"<", ">", "<=", ">="}) do
+        for _, t1 in ipairs({"{integer}", "boolean"}) do
+            for _, t2 in ipairs({"{integer}", "boolean"}) do
+                it("cannot compare " .. t1 .. " and " .. t2 .. " using " .. op, function()
+                    local code = [[
+                        function fn(a: ]] .. t1 .. [[, b: ]] .. t2 .. [[): boolean
+                            return a ]] .. op .. [[ b
+                        end
+                    ]]
+                    local ast, err = parser.parse(code)
+                    local ok, err = checker.check(ast, code, "test.titan")
+                    assert.falsy(ok)
+                    if t1 ~= t2 then
+                        assert.match("trying to use relational expression with", err)
+                    else
+                        assert.match("trying to use relational expression with two", err)
+                    end
+                end)
+            end
+        end
+    end
+
 end)
 

--- a/spec/checker_spec.lua
+++ b/spec/checker_spec.lua
@@ -539,8 +539,7 @@ describe("Titan type checker", function()
                     return a1 ]] .. op .. [[ a2
                 end
             ]]
-            local ast, err = parser.parse(code)
-            local ok, err = checker.check(ast, code, "test.titan")
+            local ok, err = run_checker(code)
             assert.truthy(ok)
         end)
     end
@@ -552,8 +551,7 @@ describe("Titan type checker", function()
                     return b1 ]] .. op .. [[ b2
                 end
             ]]
-            local ast, err = parser.parse(code)
-            local ok, err = checker.check(ast, code, "test.titan")
+            local ok, err = run_checker(code)
             assert.truthy(ok)
         end)
     end
@@ -565,8 +563,7 @@ describe("Titan type checker", function()
                     return f1 ]] .. op .. [[ f2
                 end
             ]]
-            local ast, err = parser.parse(code)
-            local ok, err = checker.check(ast, code, "test.titan")
+            local ok, err = run_checker(code)
             assert.truthy(ok)
         end)
     end
@@ -578,8 +575,7 @@ describe("Titan type checker", function()
                     return i1 ]] .. op .. [[ i2
                 end
             ]]
-            local ast, err = parser.parse(code)
-            local ok, err = checker.check(ast, code, "test.titan")
+            local ok, err = run_checker(code)
             assert.truthy(ok)
         end)
     end
@@ -591,8 +587,7 @@ describe("Titan type checker", function()
                     return i ]] .. op .. [[ f
                 end
             ]]
-            local ast, err = parser.parse(code)
-            local ok, err = checker.check(ast, code, "test.titan")
+            local ok, err = run_checker(code)
             assert.truthy(ok)
         end)
     end
@@ -604,8 +599,7 @@ describe("Titan type checker", function()
                     return s1 ]] .. op .. [[ s2
                 end
             ]]
-            local ast, err = parser.parse(code)
-            local ok, err = checker.check(ast, code, "test.titan")
+            local ok, err = run_checker(code)
             assert.truthy(ok)
         end)
     end
@@ -617,8 +611,7 @@ describe("Titan type checker", function()
                     return a1 ]] .. op .. [[ a2
                 end
             ]]
-            local ast, err = parser.parse(code)
-            local ok, err = checker.check(ast, code, "test.titan")
+            local ok, err = run_checker(code)
             assert.falsy(ok)
             assert.match("trying to compare values of different types", err)
         end)
@@ -634,8 +627,7 @@ describe("Titan type checker", function()
                                 return a ]] .. op .. [[ b
                             end
                         ]]
-                        local ast, err = parser.parse(code)
-                        local ok, err = checker.check(ast, code, "test.titan")
+                        local ok, err = run_checker(code)
                         assert.falsy(ok)
                         assert.match("trying to compare values of different types", err)
                     end)
@@ -654,8 +646,7 @@ describe("Titan type checker", function()
                                 return a ]] .. op .. [[ b
                             end
                         ]]
-                        local ast, err = parser.parse(code)
-                        local ok, err = checker.check(ast, code, "test.titan")
+                        local ok, err = run_checker(code)
                         assert.falsy(ok)
                         assert.match("trying to compare values of different types", err)
                     end)
@@ -672,8 +663,7 @@ describe("Titan type checker", function()
                         return a ]] .. op .. [[ b
                     end
                 ]]
-                local ast, err = parser.parse(code)
-                local ok, err = checker.check(ast, code, "test.titan")
+                local ok, err = run_checker(code)
                 assert.falsy(ok)
                 assert.match("left hand side of relational expression is", err)
             end)
@@ -688,8 +678,7 @@ describe("Titan type checker", function()
                         return a ]] .. op .. [[ b
                     end
                 ]]
-                local ast, err = parser.parse(code)
-                local ok, err = checker.check(ast, code, "test.titan")
+                local ok, err = run_checker(code)
                 assert.falsy(ok)
                 assert.match("right hand side of relational expression is", err)
             end)
@@ -704,8 +693,7 @@ describe("Titan type checker", function()
                         return a ]] .. op .. [[ b
                     end
                 ]]
-                local ast, err = parser.parse(code)
-                local ok, err = checker.check(ast, code, "test.titan")
+                local ok, err = run_checker(code)
                 assert.falsy(ok)
                 assert.match("left hand side of relational expression is", err)
             end)
@@ -720,8 +708,7 @@ describe("Titan type checker", function()
                         return a ]] .. op .. [[ b
                     end
                 ]]
-                local ast, err = parser.parse(code)
-                local ok, err = checker.check(ast, code, "test.titan")
+                local ok, err = run_checker(code)
                 assert.falsy(ok)
                 assert.match("right hand side of relational expression is", err)
             end)
@@ -736,8 +723,7 @@ describe("Titan type checker", function()
                         return a ]] .. op .. [[ b
                     end
                 ]]
-                local ast, err = parser.parse(code)
-                local ok, err = checker.check(ast, code, "test.titan")
+                local ok, err = run_checker(code)
                 assert.falsy(ok)
                 assert.match("left hand side of relational expression is", err)
             end)
@@ -752,8 +738,7 @@ describe("Titan type checker", function()
                         return a ]] .. op .. [[ b
                     end
                 ]]
-                local ast, err = parser.parse(code)
-                local ok, err = checker.check(ast, code, "test.titan")
+                local ok, err = run_checker(code)
                 assert.falsy(ok)
                 assert.match("right hand side of relational expression is", err)
             end)
@@ -769,8 +754,7 @@ describe("Titan type checker", function()
                             return a ]] .. op .. [[ b
                         end
                     ]]
-                    local ast, err = parser.parse(code)
-                    local ok, err = checker.check(ast, code, "test.titan")
+                    local ok, err = run_checker(code)
                     assert.falsy(ok)
                     if t1 ~= t2 then
                         assert.match("trying to use relational expression with", err)

--- a/titan-compiler/checker.lua
+++ b/titan-compiler/checker.lua
@@ -443,11 +443,22 @@ function checkexp(node, st, errors, context)
                 node.rhs = trytofloat(node.rhs)
                 trhs = node.rhs._type
             end
-            if not types.equals(tlhs, types.Integer) and not types.equals(tlhs, types.Float) then
-                typeerror(errors, "left hand side of relational expression is a " .. types.tostring(tlhs) .. " instead of a number", pos)
-            end
-            if not types.equals(trhs, types.Integer) and not types.equals(trhs, types.Float) then
-                typeerror(errors, "right hand side of relational expression is a " .. types.tostring(trhs) .. " instead of a number", pos)
+            if not types.equals(tlhs, trhs) then
+                if not types.equals(tlhs, types.Integer) and not types.equals(tlhs, types.Float) and types.equals(trhs, types.Integer) or types.equals(trhs, types.Float) then
+                    typeerror(errors, "left hand side of relational expression is a " .. types.tostring(tlhs) .. " instead of a number", pos)
+                elseif not types.equals(trhs, types.Integer) and not types.equals(trhs, types.Float) and types.equals(tlhs, types.Integer) or types.equals(tlhs, types.Float) then
+                    typeerror(errors, "right hand side of relational expression is a " .. types.tostring(trhs) .. " instead of a number", pos)
+                elseif not types.equals(tlhs, types.String) and types.equals(trhs, types.String) then
+                    typeerror(errors, "left hand side of relational expression is a " .. types.tostring(tlhs) .. " instead of a string", pos)
+                elseif not types.equals(trhs, types.String) and types.equals(tlhs, types.String) then
+                    typeerror(errors, "right hand side of relational expression is a " .. types.tostring(trhs) .. " instead of a string", pos)
+                else
+                    typeerror(errors, "trying to use relational expression with " .. types.tostring(tlhs) .. " and " .. types.tostring(trhs), pos)
+                end
+            else
+                if not types.equals(tlhs, types.Integer) and not types.equals(tlhs, types.Float) and not types.equals(tlhs, types.String) then
+                    typeerror(errors, "trying to use relational expression with two " .. types.tostring(tlhs) .. " values", pos)
+                end
             end
             node._type = types.Boolean
         elseif op == "+" or op == "-" or op == "*" or op == "%" or op == "//" then


### PR DESCRIPTION
The following example was not type checking:
```lua
function fn(a: string, b: string):boolean
    return a < b
end
```
This PR fixes the type checker to allow comparing strings with relational operators and adds some type checker tests to the following binary operations: `==`, `~=`, `<`, `>`, `<=`, and `>=`.