### PR TITLE
Fixing repository name in the build status and coverage results

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Titan
-[![Build Status](https://travis-ci.org/titan-lang/titan-v0.svg?branch=master)](https://travis-ci.org/titan-lang/titan-v0)
-[![Coverage Status](https://codecov.io/gh/titan-lang/titan-v0/coverage.svg?branch=master)](https://codecov.io/gh/titan-lang/titan-v0/branch/master)
+[![Build Status](https://travis-ci.org/titan-lang/titan.svg?branch=master)](https://travis-ci.org/titan-lang/titan)
+[![Coverage Status](https://codecov.io/gh/titan-lang/titan/coverage.svg?branch=master)](https://codecov.io/gh/titan-lang/titan/branch/master)
 
 Titan is a new programming language, designed to be a statically-typed,
 ahead-of-time compiled sister language to [Lua](http://www.lua.org). It is an


### PR DESCRIPTION
This PR simply fixes the `README.md` to use the new repository name (`titan`) instead of the old one (`titan-v0`) in the build status and coverage results.