### PR TITLE
Barebones template function for code generation

### DIFF
--- a/spec/coder_spec.lua
+++ b/spec/coder_spec.lua
@@ -102,7 +102,7 @@ describe("Titan code generator", function()
         assert.truthy(ok, err)
     end)
 
-    it("tests step value in 'for'", function()
+    it("tests integer step value in 'for'", function()
         local code = [[
             function forstep(f: integer, t: integer, s: integer): integer
                 local v: integer = 0
@@ -122,7 +122,7 @@ describe("Titan code generator", function()
         assert.truthy(ok, err)
     end)
 
-    it("tests postive literals in 'for'", function()
+    it("tests integer postive literals in 'for'", function()
         local code = [[
             function forstep(): integer
                 local v: integer = 0
@@ -142,7 +142,7 @@ describe("Titan code generator", function()
         assert.truthy(ok, err)
     end)
 
-    it("tests negative literals in 'for'", function()
+    it("tests integer negative literals in 'for'", function()
         local code = [[
             function forstep(): integer
                 local v: integer = 0
@@ -159,6 +159,66 @@ describe("Titan code generator", function()
         local ok, err = generate(ast, "titan_test")
         assert.truthy(ok, err)
         local ok, err = call("titan_test", "x = titan_test.forstep();assert(x==30)")
+        assert.truthy(ok, err)
+    end)
+
+    it("tests float step value in 'for'", function()
+        local code = [[
+            function forstep(f: float, t: float, s: float): float
+                local v: float = 0
+                for i = f, t, s do
+                    v = v + i
+                end
+                return v
+            end
+        ]]
+        local ast, err = parser.parse(code)
+        assert.truthy(ast, err)
+        local ok, err = checker.check(ast, code, "test.titan")
+        assert.truthy(ok, err)
+        local ok, err = generate(ast, "titan_test")
+        assert.truthy(ok, err)
+        local ok, err = call("titan_test", "x = titan_test.forstep(1.5,10.5,0.5);assert(x==114.0)")
+        assert.truthy(ok, err)
+    end)
+
+    it("tests float postive literals in 'for'", function()
+        local code = [[
+            function forstep(): float
+                local v: float = 0
+                for i = 1.5, 10.5, 0.5 do
+                    v = v + i
+                end
+                return v
+            end
+        ]]
+        local ast, err = parser.parse(code)
+        assert.truthy(ast, err)
+        local ok, err = checker.check(ast, code, "test.titan")
+        assert.truthy(ok, err)
+        local ok, err = generate(ast, "titan_test")
+        assert.truthy(ok, err)
+        local ok, err = call("titan_test", "x = titan_test.forstep();assert(x==114.0)")
+        assert.truthy(ok, err)
+    end)
+
+    it("tests float negative literals in 'for'", function()
+        local code = [[
+            function forstep(): float
+                local v: float = 0
+                for i = 9.5, 1.5, -0.5 do
+                    v = v + i
+                end
+                return v
+            end
+        ]]
+        local ast, err = parser.parse(code)
+        assert.truthy(ast, err)
+        local ok, err = checker.check(ast, code, "test.titan")
+        assert.truthy(ok, err)
+        local ok, err = generate(ast, "titan_test")
+        assert.truthy(ok, err)
+        local ok, err = call("titan_test", "x = titan_test.forstep();assert(x==93.5)")
         assert.truthy(ok, err)
     end)
 

--- a/titan-compiler/coder.lua
+++ b/titan-compiler/coder.lua
@@ -4,6 +4,15 @@ local coder = {}
 
 local codeexp, codestat
 
+local function output(code, vars)
+    local substitutions = setmetatable(vars, {
+        __index = function(_, k)
+            error("Internal compiler error: missing template variable " .. k)
+        end
+    })
+    return (string.gsub(code, "$([%u%d_]+)", substitutions))
+end
+
 local function quotestr(s)
     s = s:gsub("\\", "\\\\")
         :gsub("\a", "\\a")

--- a/titan-compiler/coder.lua
+++ b/titan-compiler/coder.lua
@@ -516,7 +516,7 @@ local function codeassignment(ctx, node)
                     _slot = (TValue *)luaH_getint(_t, _k);
                     TValue _vk; setivalue(&_vk, _k);
                     if (_slot == luaO_nilobject)    /* no previous entry? */
-                            _slot = luaH_newkey(L, _t, &_vk);    /* create one */
+                        _slot = luaH_newkey(L, _t, &_vk);   /* create one */
                 }
                 $CSET
             }
@@ -861,8 +861,8 @@ local function codebinaryop(ctx, node, iscondition)
                 $CTMP
                 $TMPNAME = $LCODE;
                 if(!$TMPNAME) {
-                  $RSTATS;
-                  $TMPNAME = $RCODE;
+                    $RSTATS;
+                    $TMPNAME = $RCODE;
                 }
                 $TMPSET;
             ]], {
@@ -932,9 +932,9 @@ local function codeindex(ctx, node, iscondition)
 
             const TValue *_s;
             if (_actual_i < _t->sizearray) {
-                    _s = &_t->array[_actual_i];
+                _s = &_t->array[_actual_i];
             } else {
-                    _s = luaH_getint(_t, _k);
+                _s = luaH_getint(_t, _k);
             }
 
             $CFINISH
@@ -1065,18 +1065,18 @@ function codeexp(ctx, node, iscondition, target)
         local code = render([[
           $CTMP
           {
-          size_t _len = 0;
-          size_t _tl = 0;
-          $STRS
-          if(_len <= LUAI_MAXSHORTLEN) {
-              char _buff[LUAI_MAXSHORTLEN];
-              $COPIES
-              $TMPNAME = luaS_newlstr(L, _buff, _len);
-          } else {
-              $TMPNAME = luaS_createlngstrobj(L, _len);
-              char *_buff = getstr($TMPNAME);
-              $COPIES
-          }
+              size_t _len = 0;
+              size_t _tl = 0;
+              $STRS
+              if(_len <= LUAI_MAXSHORTLEN) {
+                  char _buff[LUAI_MAXSHORTLEN];
+                  $COPIES
+                  $TMPNAME = luaS_newlstr(L, _buff, _len);
+              } else {
+                  $TMPNAME = luaS_createlngstrobj(L, _len);
+                  char *_buff = getstr($TMPNAME);
+                  $COPIES
+              }
           }
           setsvalue(L, $TMPSLOT, $TMPNAME);
         ]], {
@@ -1437,7 +1437,7 @@ function coder.generate(modname, ast)
         }))
         for i, slot in ipairs(varslots) do
             table.insert(initvars, i+1, render([[
-              $SLOT = &_upvals[$I];
+                $SLOT = &_upvals[$I];
             ]], {
                 SLOT = slot,
                 I = c_integer_literal(i),

--- a/titan-compiler/coder.lua
+++ b/titan-compiler/coder.lua
@@ -769,7 +769,7 @@ local function codebinaryop(ctx, node, iscondition)
                 %s
                 %s = %s;
                 if(%s) {
-                  %s  
+                  %s
                   %s = %s;
                 }
                 %s;
@@ -788,7 +788,7 @@ local function codebinaryop(ctx, node, iscondition)
                 %s
                 %s = %s;
                 if(!%s) {
-                  %s  
+                  %s
                   %s = %s;
                 }
                 %s;
@@ -955,7 +955,7 @@ function codeexp(ctx, node, iscondition, target)
           }
           }
           setsvalue(L, %s, %s);
-        ]], ctmp, table.concat(strs, "\n"), 
+        ]], ctmp, table.concat(strs, "\n"),
             table.concat(copies, "\n"), tmpname, tmpname, tmpname,
             table.concat(copies, "\n"), tmpslot, tmpname), tmpname
     else
@@ -1028,7 +1028,7 @@ local function codefuncdec(tlcontext, node)
     for i, param in ipairs(node.params) do
         table.insert(pnames, param._cvar)
         table.insert(stats, ctype(param._type) .. " " .. param._cvar .. " = 0;")
-        table.insert(stats, checkandget(param._type, param._cvar, 
+        table.insert(stats, checkandget(param._type, param._cvar,
             "(func+ " .. i .. ")", node._lin))
     end
     table.insert(stats, string.format([[
@@ -1122,10 +1122,10 @@ int luaopen_%s(lua_State *L) {
 local init = [[
 void %s_init(lua_State *L) {
     if(!_initialized) {
-        _initialized = 1;    
+        _initialized = 1;
         %s
     }
-}    
+}
 ]]
 
 function coder.generate(modname, ast)
@@ -1144,7 +1144,7 @@ function coder.generate(modname, ast)
     local gvars = {}
 
     local initctx = newcontext()
-    
+
     for _, node in pairs(ast) do
         if not node._ignore then
             local tag = node._tag
@@ -1206,7 +1206,7 @@ function coder.generate(modname, ast)
                 lua_pushvalue(L, 2);
                 lua_rawget(L, lua_upvalueindex(1));
                 if(lua_isnil(L, -1)) {
-                    return luaL_error(L, 
+                    return luaL_error(L,
                         "global variable '%%s' does not exist in Titan module '%%s'",
                         lua_tostring(L, 2), "%s");
                 }
@@ -1220,19 +1220,19 @@ function coder.generate(modname, ast)
                 lua_pushvalue(L, 2);
                 lua_rawget(L, lua_upvalueindex(1));
                 if(lua_isnil(L, -1)) {
-                    return luaL_error(L, 
+                    return luaL_error(L,
                         "global variable '%%s' does not exist in Titan module '%%s'",
                         lua_tostring(L, 2), "%s");
                 }
                 switch(lua_tointeger(L, -1)) {
                     %s
                 }
-                return 1;                
+                return 1;
             }
          ]], modname, table.concat(switch_get, "\n"), modname, table.concat(switch_set, "\n")))
- 
+
         local nslots = initctx.nslots + #varslots + 1
-         
+
         table.insert(initvars, 1, string.format([[
         luaL_newmetatable(L, "titan module %s"); /* push metatable */
         int _meta = lua_gettop(L);
@@ -1257,14 +1257,14 @@ function coder.generate(modname, ast)
         sethvalue(L, L->top, _map);
         L->top++;
         lua_pushcclosure(L, __newindex, 1);
-        lua_setfield(L, _meta, "__newindex");        
+        lua_setfield(L, _meta, "__newindex");
         L->top++;
         sethvalue(L, L->top-1, _map);
         ]], modname, modname, nslots, nslots, nslots, nslots, nslots, #varslots+1,
             #varslots+1))
         for i, slot in ipairs(varslots) do
             table.insert(initvars, i+1, string.format([[
-              %s = &_upvals[%d];  
+              %s = &_upvals[%d];
             ]], slot, i))
         end
         for i, var in ipairs(gvars) do
@@ -1277,7 +1277,7 @@ function coder.generate(modname, ast)
         L->top = _base-1;
         ]], modname))
     end
-    
+
     table.insert(code, string.format(init, modname, table.concat(initvars, "\n")))
 
     table.insert(code, string.format(postamble, modname, modname, table.concat(funcs, "\n"), modname))

--- a/titan-compiler/coder.lua
+++ b/titan-compiler/coder.lua
@@ -4,13 +4,17 @@ local coder = {}
 
 local codeexp, codestat
 
-local function output(code, vars)
-    local substitutions = setmetatable(vars, {
-        __index = function(_, k)
+-- Barebones string-based template function for generating C code.
+-- Replaces $VAR placeholders in the `code` template by the corresponding
+-- strings in the `substs` table.
+local function output(code, substs)
+    return (string.gsub(code, "$([%w_]+)", function(k)
+        local v = substs[k]
+        if not v then
             error("Internal compiler error: missing template variable " .. k)
         end
-    })
-    return (string.gsub(code, "$([%u%d_]+)", substitutions))
+        return v
+    end))
 end
 
 local function quotestr(s)

--- a/titan-compiler/coder.lua
+++ b/titan-compiler/coder.lua
@@ -368,21 +368,23 @@ local function codefor(ctx, node)
         local ilit = node2literal(node.inc)
         if ilit then
             if ilit > 0 then
-                subs.ILIT = c_integer_literal(ilit)
                 local tmpl
                 if types.equals(node.decl._type, types.Integer) then
+                    subs.ILIT = c_integer_literal(ilit)
                     tmpl = "$CVAR = l_castU2S(l_castS2U($CVAR) + $ILIT)"
                 else
+                    subs.ILIT = c_float_literal(ilit)
                     tmpl = "$CVAR += $ILIT"
                 end
                 cstep = output(tmpl, subs)
                 ccmp = output("$CVAR <= _forlimit", subs)
             else
-                subs.NEGILIT = c_integer_literal(-ilit)
                 if types.equals(node.decl._type, types.Integer) then
+                    subs.NEGILIT = c_integer_literal(-ilit)
                     cstep = output("$CVAR = l_castU2S(l_castS2U($CVAR) - $NEGILIT)", subs)
                 else
-                    cstep = output("$CVAR -= $ILIT", subs)
+                    subs.NEGILIT = c_float_literal(-ilit)
+                    cstep = output("$CVAR -= $NEGILIT", subs)
                 end
                 ccmp = output("_forlimit <= $CVAR", subs)
             end


### PR DESCRIPTION
We replaced all uses of string.format for generating C code with a little function that used named placehoders instead of positional placeholders.

There are also some very minor code cleanups (whitespace fixes, C literal creation, and C identifier creation)

----

Bikesheding moment: I don't like the "output" name for the function because it's ambiguous about being a noun or verb and because it isn't specific to what the function does. But I couldn't think of something better :/