### PR TITLE
add GC checks to loops and function preambles

### DIFF
--- a/titan-compiler/coder.lua
+++ b/titan-compiler/coder.lua
@@ -274,7 +274,6 @@ local function codewhile(ctx, node)
     else
         tmpl = [[
             while(1) {
-                luaC_checkGC(L);
                 $CSTATS
                 if(!($CEXP)) {
                     break;


### PR DESCRIPTION
Just discovered that Lua does not do a GC step on the internal object allocation primitives, but on the *opcodes* that allocate (as well as C API functions that call those primitives), so Titan was not actually doing any GC while running. Plugged this hole by adding calls to `luaC_checkGC` to loop bodies and function preambles, while we think of a better policy, and how to be smarter about avoiding adding those calls to loops that do not do any allocation.