### PR TITLE
Add missing modules to rockspec

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Titan must be installed in a standard location;
 [LuaRocks](http://luarocks.org) will do this, and will also install all dependencies automatically.
 
         $ [install luarocks]
-        $ luarocks install titan-lang-scm-1.rockspec
+        $ luarocks install titan-scm-1.rockspec
 
 # Usage
 

--- a/titan-scm-1.rockspec
+++ b/titan-scm-1.rockspec
@@ -1,7 +1,7 @@
-package = "titan-v0"
+package = "titan"
 version = "scm-1"
 source = {
-   url = "git+https://github.com/titan-lang/titan-v0"
+   url = "git+https://github.com/titan-lang/titan"
 }
 description = {
    summary = "Initial prototype of the Titan compiler",
@@ -10,7 +10,7 @@ description = {
       This is a proof-of-concept, implementing a subset of
       the Titan language.
    ]],
-   homepage = "http://github.com/titan-lang/titan-v0",
+   homepage = "http://github.com/titan-lang/titan",
    license = "MIT"
 }
 dependencies = {

--- a/titan-v0-scm-1.rockspec
+++ b/titan-v0-scm-1.rockspec
@@ -24,10 +24,13 @@ build = {
    modules = {
       ["titan-compiler.ast"] = "titan-compiler/ast.lua",
       ["titan-compiler.checker"] = "titan-compiler/checker.lua",
+      ["titan-compiler.coder"] = "titan-compiler/coder.lua",
       ["titan-compiler.lexer"] = "titan-compiler/lexer.lua",
       ["titan-compiler.parser"] = "titan-compiler/parser.lua",
+      ["titan-compiler.pretty"] = "titan-compiler/pretty.lua",
       ["titan-compiler.symtab"] = "titan-compiler/symtab.lua",
       ["titan-compiler.syntax_errors"] = "titan-compiler/syntax_errors.lua",
+      ["titan-compiler.types"] = "titan-compiler/types.lua",
       ["titan-compiler.util"] = "titan-compiler/util.lua",
    },
    install = {


### PR DESCRIPTION
Fixed an issue where running titanc outside the titan git repository
would result in a "module not found" error for titan-compiler.types

Question for the rockspec experts: is editing the existing rockspec file the way to go or should I have created a new one?