### PR TITLE
Add records to the parser

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -9,3 +9,8 @@ insert_final_newline = true
 indent_style = space
 indent_size = 4
 trim_trailing_whitespace = true
+
+[*.titan]
+indent_style = space
+indent_size = 4
+trim_trailing_whitespace = true

--- a/doc/manual.md
+++ b/doc/manual.md
@@ -1,6 +1,16 @@
 # Titan Language Reference
 
-## Arrays
+## Types
+
+### Basic Types
+
+- `nil`
+- `boolean`
+- `integer`
+- `float`
+- `string`
+
+### Arrays
 
 Array types in Titan have the form `{ t }`, where `t` is any Titan type
 (including other array types, so `{ { integer } }` is the type for an array of
@@ -17,3 +27,30 @@ the new array will have the type you declared.
 The only time where no context is available is when you declaring a new
 variable and you have not given a type to it; in that case the array will have
 type `{ integer }`.
+
+### Records
+
+Records are nominal and should be declared in the top level, like the following
+example.
+
+    record Point
+        x: float
+        y: float
+    end
+
+    record Circle
+        center: Point
+        radius: float
+    end
+
+After the top level declaration, you may create records with the `.new`
+constructor:
+
+    local p = Point.new(1, 2)
+    local c = Circle.new(p, 3.5)
+
+You can access the fields with the dot operator:
+
+    local a = p.x
+    p.y = 2
+

--- a/doc/manual.md
+++ b/doc/manual.md
@@ -2,13 +2,18 @@
 
 ## Arrays
 
-Array types in Titan have the form `{ t }`, where `t` is any Titan type (including other array types, so `{ { integer } }`
-is the type for an array of arrays of integers, for example. 
+Array types in Titan have the form `{ t }`, where `t` is any Titan type
+(including other array types, so `{ { integer } }` is the type for an array of
+arrays of integers, for example.
 
-You can create an empty array with the `{}` expression: Titan
-will try to guess the type of this array from the context where you are creating it. For example, if you are assigning the
-new array to an array-typed variable, the array will have the same type of the variable. If you are passing the
-array as an argument to a function that expects an array-type parameter, the new array will have the same
-type as the parameter. If you are declaring a new variable with an explicit array type declaration, the new
-array will have the type you declared. The only time where no context is available is when you declaring a new variable
-and you have not given a type to it; in that case the array will have type `{ integer }`.
+You can create an empty array with the `{}` expression: Titan will try to guess
+the type of this array from the context where you are creating it.
+For example, if you are assigning the new array to an array-typed variable, the
+array will have the same type of the variable.
+If you are passing the array as an argument to a function that expects an
+array-type parameter, the new array will have the same type as the parameter.
+If you are declaring a new variable with an explicit array type declaration,
+the new array will have the type you declared.
+The only time where no context is available is when you declaring a new
+variable and you have not given a type to it; in that case the array will have
+type `{ integer }`.

--- a/spec/parser_spec.lua
+++ b/spec/parser_spec.lua
@@ -343,4 +343,75 @@ end)
                         { _tag = "Exp_Table" } } } } },
         })
     end)
+
+    it("can parse record declarations", function()
+        local program, err =
+            parse_file("./testfiles/records.titan")
+        assert.truthy(program)
+        assert_ast(program, {
+            { _tag = "TopLevel_Record",
+              name = "Point",
+              fields = {
+                { name = "x", type = { name = "float" } },
+                { name = "y", type = { name = "float" } } } },
+            { _tag = "TopLevel_Record",
+              name = "List",
+              fields = {
+                { name = "p",
+                  type = { subtype = { name = "Point" } } },
+                { name = "next", type = { name = "List" } } } },
+        })
+        assert_ast(program[3].block.stats, {
+            { decl = { name = "p1" },
+              exp = {
+                _tag = "Exp_Call",
+                args = { args = { { value = 1.1 }, { value = 2.2 } } },
+                exp = { var = {
+                  _tag = "Var_Dot",
+                  exp = { var = { name = "Point" } },
+                  name = "new" } } } },
+            { decl = {
+                name = "l1",
+                type = { name = "List" } },
+              exp = {
+                _tag = "Exp_Call",
+                args = { args = 
+                  { { _tag = "Exp_Table" }, { _tag = "Exp_Nil" } } },
+                exp = { var = {
+                  _tag = "Var_Dot",
+                  exp = { var = { name = "List" } },
+                  name = "new" } } } },
+            { decl = { name = "a" },
+              exp = {
+                op = "+",
+                lhs = {
+                  var = {
+                    _tag = "Var_Dot",
+                    exp = { var = { name = "p1" } },
+                    name = "x" } },
+                rhs = {
+                  var = {
+                    _tag = "Var_Dot",
+                    exp = { var = { name = "p1" } },
+                    name = "y" } } } },
+            { decl = { name = "b" },
+              exp = {
+                var = {
+                  _tag = "Var_Dot", 
+                  name = "x",
+                  exp = { var = {
+                    _tag = "Var_Array",
+                    exp2 = { value = 1 },
+                    exp1 = { var = {
+                      _tag = "Var_Dot",
+                      name = "p",
+                      exp = { var = {
+                        name = "l1" } } } } } } } } },
+            { var = {
+                _tag = "Var_Dot",
+                exp = { var = { name = "p1" } },
+                name = "x" },
+              exp = { var = { name = "a" } } }
+        })
+    end)
 end)

--- a/spec/parser_spec.lua
+++ b/spec/parser_spec.lua
@@ -84,13 +84,13 @@ describe("Titan parser", function()
         local program, err = parse_file("./testfiles/types.titan")
         assert.truthy(program)
         assert_ast(program, {
-            { decl = { type = { _tag = "Type_Basic", name = "nil" } } },
-            { decl = { type = { _tag = "Type_Basic", name = "int" } } },
+            { decl = { type = { _tag = "Type_Name", name = "nil" } } },
+            { decl = { type = { _tag = "Type_Name", name = "int" } } },
             { decl = { type = { _tag = "Type_Array", subtype =
-                                    {_tag = "Type_Basic", name = "int" } } } },
+                                    {_tag = "Type_Name", name = "int" } } } },
             { decl = { type = { _tag = "Type_Array", subtype =
                                 { _tag = "Type_Array", subtype =
-                                    {_tag = "Type_Basic", name = "int" } } } } },
+                                    {_tag = "Type_Name", name = "int" } } } } },
         })
     end)
 
@@ -133,11 +133,11 @@ describe("Titan parser", function()
             { _tag = "Stat_While",
               condition = { _tag = "Exp_Bool" },
               block = { _tag = "Stat_Block" } },
-            
+
             { _tag = "Stat_Repeat",
               block = { _tag = "Stat_Block" },
               condition = { _tag = "Exp_Bool" }, },
-            
+
             { _tag = "Stat_If",
                 thens = {
                     { _tag = "Then_Then", condition = { value = 10 } },
@@ -193,7 +193,7 @@ describe("Titan parser", function()
 
     it("can parse return statements", function()
         -- Just check if it succeeds or fails in all the cases.
-        
+
         local program, err = parse_file("./testfiles/return_statements.titan")
         assert.truthy(program)
     end)

--- a/spec/parser_spec.lua
+++ b/spec/parser_spec.lua
@@ -295,7 +295,7 @@ end)
                 exp = { _tag = "Exp_Binop", op = "^",
                     rhs = { value = 3 },
                     lhs = { _tag = "Exp_Var", var = {
-                        _tag = "Var_Index",
+                        _tag = "Var_Array",
                         exp2 = { value = 2 },
                         exp1 = { _tag = "Exp_Call",
                             args = { _tag = "Args_Method", method = "foo" },

--- a/spec/parser_spec.lua
+++ b/spec/parser_spec.lua
@@ -295,7 +295,7 @@ end)
                 exp = { _tag = "Exp_Binop", op = "^",
                     rhs = { value = 3 },
                     lhs = { _tag = "Exp_Var", var = {
-                        _tag = "Var_Array",
+                        _tag = "Var_Bracket",
                         exp2 = { value = 2 },
                         exp1 = { _tag = "Exp_Call",
                             args = { _tag = "Args_Method", method = "foo" },
@@ -400,7 +400,7 @@ end)
                   _tag = "Var_Dot", 
                   name = "x",
                   exp = { var = {
-                    _tag = "Var_Array",
+                    _tag = "Var_Bracket",
                     exp2 = { value = 1 },
                     exp1 = { var = {
                       _tag = "Var_Dot",

--- a/testfiles/records.titan
+++ b/testfiles/records.titan
@@ -1,0 +1,25 @@
+record Point
+    x: float
+    y: float
+end
+
+record List
+    p: {Point}
+    next: List
+end
+
+function foo(): nil
+    local p1 = Point.new(1.1, 2.2)
+
+    -- future syntax with initializer lists:
+    -- local p1: Point = { x = 3.3, y = 4.4 }
+    -- local p2: Point = { 5.5, 6.6 }
+
+    local l1: List = List.new({}, nil)
+
+    local a = p1.x + p1.y
+    local b = l1.p[1].x
+
+    p1.x = a
+end
+

--- a/titan-compiler/ast.lua
+++ b/titan-compiler/ast.lua
@@ -36,7 +36,7 @@ types.Then = {
 
 types.Var = {
     Name    = {"name"},
-    Array   = {"exp1", "exp2"},
+    Bracket = {"exp1", "exp2"},
     Dot     = {"exp", "name"},
 }
 

--- a/titan-compiler/ast.lua
+++ b/titan-compiler/ast.lua
@@ -35,7 +35,7 @@ types.Then = {
 
 types.Var = {
     Name    = {"name"},
-    Index   = {"exp1", "exp2"},
+    Array   = {"exp1", "exp2"},
 }
 
 types.Exp = {

--- a/titan-compiler/ast.lua
+++ b/titan-compiler/ast.lua
@@ -4,7 +4,7 @@ local ast = {}
 local types = {}
 
 types.Type = {
-    Basic   = {"name"},
+    Name    = {"name"},
     Array   = {"subtype"},
 }
 

--- a/titan-compiler/ast.lua
+++ b/titan-compiler/ast.lua
@@ -11,6 +11,7 @@ types.Type = {
 types.TopLevel = {
     Func    = {"islocal", "name", "params", "rettype", "block"},
     Var     = {"islocal", "decl", "value"},
+    Record  = {"name", "fields"},
 }
 
 types.Decl = {
@@ -36,6 +37,7 @@ types.Then = {
 types.Var = {
     Name    = {"name"},
     Array   = {"exp1", "exp2"},
+    Dot     = {"exp", "name"},
 }
 
 types.Exp = {

--- a/titan-compiler/checker.lua
+++ b/titan-compiler/checker.lua
@@ -284,7 +284,7 @@ function checkstat(node, st, errors)
         end
         checkexp(node.exp, st, errors, node.var._type)
         node.exp = trycoerce(node.exp, node.var._type)
-        if node.var._tag ~= "Var_Array" or not types.equals(node.exp._type, types.Nil) then
+        if node.var._tag ~= "Var_Bracket" or not types.equals(node.exp._type, types.Nil) then
             checkmatch("assignment", node.var._type, node.exp._type, errors, node.var._pos)
         end
     elseif tag == "Stat_Call" then
@@ -338,7 +338,7 @@ function checkexp(node, st, errors, context)
             node._decl = decl
             node._type = decl._type
         end
-    elseif tag == "Var_Array" then
+    elseif tag == "Var_Bracket" then
         local l, _ = util.get_line_number(errors.subject, node._pos)
         node._lin = l
         checkexp(node.exp1, st, errors, context and types.Array(context))

--- a/titan-compiler/checker.lua
+++ b/titan-compiler/checker.lua
@@ -22,7 +22,7 @@ local function typefromnode(typenode, errors)
     local tag = typenode._tag
     if tag == "Type_Array" then
         return types.Array(typefromnode(typenode.subtype, errors))
-    elseif tag == "Type_Basic" then
+    elseif tag == "Type_Name" then
         local t = types.Base(typenode.name)
         if not t then
             typeerror(errors, "type name " .. typenode.name .. " is invalid", typenode._pos)

--- a/titan-compiler/checker.lua
+++ b/titan-compiler/checker.lua
@@ -284,7 +284,7 @@ function checkstat(node, st, errors)
         end
         checkexp(node.exp, st, errors, node.var._type)
         node.exp = trycoerce(node.exp, node.var._type)
-        if node.var._tag ~= "Var_Index" or not types.equals(node.exp._type, types.Nil) then
+        if node.var._tag ~= "Var_Array" or not types.equals(node.exp._type, types.Nil) then
             checkmatch("assignment", node.var._type, node.exp._type, errors, node.var._pos)
         end
     elseif tag == "Stat_Call" then
@@ -338,7 +338,7 @@ function checkexp(node, st, errors, context)
             node._decl = decl
             node._type = decl._type
         end
-    elseif tag == "Var_Index" then
+    elseif tag == "Var_Array" then
         local l, _ = util.get_line_number(errors.subject, node._pos)
         node._lin = l
         checkexp(node.exp1, st, errors, context and types.Array(context))

--- a/titan-compiler/coder.lua
+++ b/titan-compiler/coder.lua
@@ -490,7 +490,7 @@ local function codeassignment(ctx, node)
                 CSET = cset,
             })
         end
-    elseif vtag == "Var_Array" then
+    elseif vtag == "Var_Bracket" then
         local arr = node.var.exp1
         local idx = node.var.exp2
         local etype = node.exp._type
@@ -976,7 +976,7 @@ function codeexp(ctx, node, iscondition, target)
     local tag = node._tag
     if tag == "Var_Name" then
         return codevar(ctx, node)
-    elseif tag == "Var_Array" then
+    elseif tag == "Var_Bracket" then
         return codeindex(ctx, node, iscondition)
     elseif tag == "Exp_Nil" or
                 tag == "Exp_Bool" or

--- a/titan-compiler/coder.lua
+++ b/titan-compiler/coder.lua
@@ -490,7 +490,7 @@ local function codeassignment(ctx, node)
                 CSET = cset,
             })
         end
-    elseif vtag == "Var_Index" then
+    elseif vtag == "Var_Array" then
         local arr = node.var.exp1
         local idx = node.var.exp2
         local etype = node.exp._type
@@ -976,7 +976,7 @@ function codeexp(ctx, node, iscondition, target)
     local tag = node._tag
     if tag == "Var_Name" then
         return codevar(ctx, node)
-    elseif tag == "Var_Index" then
+    elseif tag == "Var_Array" then
         return codeindex(ctx, node, iscondition)
     elseif tag == "Exp_Nil" or
                 tag == "Exp_Bool" or

--- a/titan-compiler/lexer.lua
+++ b/titan-compiler/lexer.lua
@@ -162,7 +162,7 @@ local possiblename = idstart * idrest^0
 local keywords = {
     "and", "break", "do", "else", "elseif", "end", "for", "false",
     "function", "goto", "if", "in", "local", "nil", "not", "or",
-    "repeat", "return", "then", "true", "until", "while",
+    "record", "repeat", "return", "then", "true", "until", "while",
 }
 
 for _, keyword in ipairs(keywords) do

--- a/titan-compiler/parser.lua
+++ b/titan-compiler/parser.lua
@@ -135,7 +135,7 @@ end
 
 function defs.suffix_index(pos, index)
     return function(exp)
-        return ast.Exp_Var(pos, ast.Var_Index(pos, exp, index))
+        return ast.Exp_Var(pos, ast.Var_Array(pos, exp, index))
     end
 end
 

--- a/titan-compiler/parser.lua
+++ b/titan-compiler/parser.lua
@@ -133,9 +133,9 @@ function defs.suffix_methodcall(pos, name, args)
     end
 end
 
-function defs.suffix_array(pos, index)
+function defs.suffix_bracket(pos, index)
     return function(exp)
-        return ast.Exp_Var(pos, ast.Var_Array(pos, exp, index))
+        return ast.Exp_Var(pos, ast.Var_Bracket(pos, exp, index))
     end
 end
 
@@ -260,7 +260,7 @@ local grammar = re.compile([[
 
     expsuffix       <- ({} funcargs)                        -> suffix_funccall
                      / ({} COLON NAME funcargs)             -> suffix_methodcall
-                     / ({} LBRACKET exp RBRACKET)           -> suffix_array
+                     / ({} LBRACKET exp RBRACKET)           -> suffix_bracket
                      / ({} DOT NAME)                        -> suffix_dot
 
     simpleexp       <- ({} NIL)                             -> nil_exp

--- a/titan-compiler/parser.lua
+++ b/titan-compiler/parser.lua
@@ -186,8 +186,8 @@ local grammar = re.compile([[
 
     decl            <- ({} NAME (COLON type)? -> opt)       -> Decl_Decl
 
-    type            <- ({} NIL -> 'nil')                    -> Type_Basic
-                     / ({} NAME)                            -> Type_Basic
+    type            <- ({} NIL -> 'nil')                    -> Type_Name
+                     / ({} NAME)                            -> Type_Name
                      / ({} LCURLY type RCURLY)              -> Type_Array
 
     block           <- ({} {| statement* returnstat? |})    -> Stat_Block


### PR DESCRIPTION
See the manual for more details about the initial proposal. This should be the bare minimum for implementing records. Initializer lists `{x = 10, y = 10}` can be implemented later.