### PR TITLE
Add initializer lists to the parser

### DIFF
--- a/doc/manual.md
+++ b/doc/manual.md
@@ -22,9 +22,11 @@ For example, if you are assigning the new array to an array-typed variable, the
 array will have the same type of the variable.
 If you are passing the array as an argument to a function that expects an
 array-type parameter, the new array will have the same type as the parameter.
-When declaring a new variable, you should explicitly specify the type of the
-array; `local a = {}` will yield a compile time error.
-
+If you are declaring a new variable with an explicit array type declaration,
+the new array will have the type you declared.
+The only time where no context is available is when you declaring a new
+variable and you have not given a type to it; in that case the array will have
+type `{ integer }`.
 
 ### Functions
 
@@ -62,18 +64,20 @@ declare a record `Point` with the fields `x` and `y` which are floats.
         y: float
     end
 
-You can create records with initializer lists, assigning a value to each field
-either by it's name or positional order.
-For instance, you could initalize an instance of the record `Point` with: `{ x =
-3, y = 5 }`, `{ y = 5, x = 3 }` or `{ 3, 5 }`.
+You can create records with initializer lists or using the `new` constructor.
+When using initializer lists, you must assign a value to each field of the
+record with the syntax `{ (field = value)* }`.
+The `Type.new()` constructor is automatically declared and receive a parameter
+for each field in the order they were declared.
+For instance, you could initialize an instance of the record `Point` with:
+`{ x = 3, y = 5 }`, `{ y = 5, x = 3 }` or `Point.new(3, 5)`.
 In all those cases, the field `x` will receive the value `3` and the field `y`,
 `5`.
-Like arrays, Titan will try to infer the type of the initializer list, but it is
-necessary to specify the type of the record when declaring a new variable
-(`local p: Point = { 3, 5 }`).
+Like arrays constructors, Titan will try to locally infer the type of
+initializer lists.
 
 You can read and write from fields of a record instance using the dot operator
-`intance.field`. For example, `local x = p.x` and `p.y = 7`.
+`instance.field`. For example, `local x = p.x` and `p.y = 7`.
 
 ## Modules
 

--- a/doc/manual.md
+++ b/doc/manual.md
@@ -16,17 +16,15 @@ Array types in Titan have the form `{ t }`, where `t` is any Titan type
 (including other array types, so `{ { integer } }` is the type for an array of
 arrays of integers, for example.
 
-You can create an empty array with the `{}` expression: Titan will try to guess
+You can create an empty array with the `{}` expression: Titan will try to infer
 the type of this array from the context where you are creating it.
 For example, if you are assigning the new array to an array-typed variable, the
 array will have the same type of the variable.
 If you are passing the array as an argument to a function that expects an
 array-type parameter, the new array will have the same type as the parameter.
-If you are declaring a new variable with an explicit array type declaration,
-the new array will have the type you declared.
-The only time where no context is available is when you declaring a new
-variable and you have not given a type to it; in that case the array will have
-type `{ integer }`.
+When declaring a new variable, you should explicitly specify the type of the
+array; `local a = {}` will yield a compile time error.
+
 
 ### Functions
 
@@ -55,29 +53,27 @@ return values for functions.
 
 ### Records
 
-Records are nominal and should be declared in the top level, like the following
-example.
+Records types in Titan are nominal and should be declared in the top level,
+following the syntax `record Type (field: type)* end`. The following example
+declare a record `Point` with the fields `x` and `y` which are floats.
 
     record Point
         x: float
         y: float
     end
 
-    record Circle
-        center: Point
-        radius: float
-    end
+You can create records with initializer lists, assigning a value to each field
+either by it's name or positional order.
+For instance, you could initalize an instance of the record `Point` with: `{ x =
+3, y = 5 }`, `{ y = 5, x = 3 }` or `{ 3, 5 }`.
+In all those cases, the field `x` will receive the value `3` and the field `y`,
+`5`.
+Like arrays, Titan will try to infer the type of the initializer list, but it is
+necessary to specify the type of the record when declaring a new variable
+(`local p: Point = { 3, 5 }`).
 
-After the top level declaration, you may create records with the `.new`
-constructor:
-
-    local p = Point.new(1, 2)
-    local c = Circle.new(p, 3.5)
-
-You can access the fields with the dot operator:
-
-    local a = p.x
-    p.y = 2
+You can read and write from fields of a record instance using the dot operator
+`intance.field`. For example, `local x = p.x` and `p.y = 7`.
 
 ## Modules
 

--- a/spec/checker_spec.lua
+++ b/spec/checker_spec.lua
@@ -214,6 +214,17 @@ describe("Titan type checker", function()
         assert.truthy(ok, err)
     end)
 
+    it("catches named init list assigned to an array", function()
+        local code = [[
+            function fn(x: integer)
+                local arr: {integer} = { x = 10 }
+            end
+        ]]
+        local ok, err = run_checker(code)
+        assert.falsy(ok)
+        assert.match("expected { integer } but found initlist", err)
+    end)
+
     it("type-checks 'for'", function()
         local code = [[
             function fn(x: integer): integer

--- a/spec/parser_spec.lua
+++ b/spec/parser_spec.lua
@@ -315,19 +315,19 @@ describe("Titan parser", function()
 
     it("can parse table constructors", function()
         assert_expression_ast("{}",
-            { _tag = "Exp_ArrCons", exps = {} })
+            { _tag = "Exp_InitList", fields = {} })
 
         assert_expression_ast("{10,20,30}",
-            { _tag = "Exp_ArrCons", exps = {
-                { value = 10 },
-                { value = 20 },
-                { value = 30 }, }})
+            { _tag = "Exp_InitList", fields = {
+                { exp = { value = 10 } },
+                { exp = { value = 20 } },
+                { exp = { value = 30 } }, }})
 
         assert_expression_ast("{40;50;60;}", -- (semicolons)
-            { _tag = "Exp_ArrCons", exps = {
-                { value = 40 },
-                { value = 50 },
-                { value = 60 }, }})
+            { _tag = "Exp_InitList", fields = {
+                { exp = { value = 40 } },
+                { exp = { value = 50 } },
+                { exp = { value = 60 } }, }})
     end)
 
     describe("can parse while statements", function()
@@ -562,7 +562,7 @@ describe("Titan parser", function()
         assert_expression_ast([[ f {} ]],
             { _tag = "Exp_Call", args = {
                 _tag = "Args_Func", args = {
-                    { _tag = "Exp_ArrCons" } } } })
+                    { _tag = "Exp_InitList" } } } })
     end)
 
     it("can parse method calls without the optional parenthesis", function()
@@ -578,7 +578,7 @@ describe("Titan parser", function()
         assert_expression_ast([[ o:m {} ]],
             { _tag = "Exp_Call", args = {
                 _tag = "Args_Method", args = {
-                    { _tag = "Exp_ArrCons" } } } })
+                    { _tag = "Exp_InitList" } } } })
     end)
 
     it("only allows call expressions as statements", function()
@@ -664,28 +664,8 @@ describe("Titan parser", function()
 
         assert_expression_ast([[ { p = {}, next = nil } ]],
             { _tag = "Exp_InitList", fields = {
-                { name = "p",    exp = { _tag = "Exp_ArrCons" } },
+                { name = "p",    exp = { _tag = "Exp_InitList" } },
                 { name = "next", exp = { _tag = "Exp_Nil" } } }})
-
-        assert_expression_ast([[ Point.new(1.1, 2.2) ]],
-            { _tag = "Exp_Call",
-                args = { args = {
-                  { value = 1.1 },
-                  { value = 2.2 } } },
-                exp = { var = {
-                    _tag = "Var_Dot",
-                    exp = { var = { name = "Point" } },
-                    name = "new" } } })
-
-        assert_expression_ast([[ List.new({}, nil) ]],
-            { _tag = "Exp_Call",
-                args = { args = {
-                  { _tag = "Exp_ArrCons" },
-                  { _tag = "Exp_Nil" } } },
-                exp = { var = {
-                    _tag = "Var_Dot",
-                    exp = { var = { name = "List" } },
-                    name = "new" } } })
     end)
 
     it("can parse record field access", function()
@@ -963,12 +943,8 @@ describe("Titan parser", function()
 
         assert_expression_syntax_error([[ f(42,) ]], "ExpExpList")
 
-        assert_expression_syntax_error([[ y{42 ]], "RCurlyArrCons")
+        assert_expression_syntax_error([[ y{42 ]], "RCurlyInitList")
 
-        assert_expression_syntax_error([[ y{42,,} ]], "ExpArrList")
-
-        assert_expression_syntax_error([[ y{x=42 ]], "RCurlyInitList")
-
-        assert_expression_syntax_error([[ y{x=42,,} ]], "FieldFieldList")
+        assert_expression_syntax_error([[ y{42,,} ]], "ExpFieldList")
     end)
 end)

--- a/spec/parser_spec.lua
+++ b/spec/parser_spec.lua
@@ -315,19 +315,19 @@ describe("Titan parser", function()
 
     it("can parse table constructors", function()
         assert_expression_ast("{}",
-            { _tag = "Exp_Table", exps = {} })
+            { _tag = "Exp_InitList", fields = {} })
 
         assert_expression_ast("{10,20,30}",
-            { _tag = "Exp_Table", exps = {
-                { value = 10 },
-                { value = 20 },
-                { value = 30 }, }})
+            { _tag = "Exp_InitList", fields = {
+                { exp = { value = 10 } },
+                { exp = { value = 20 } },
+                { exp = { value = 30 } }, }})
 
         assert_expression_ast("{40;50;60;}", -- (semicolons)
-            { _tag = "Exp_Table", exps = {
-                { value = 40 },
-                { value = 50 },
-                { value = 60 }, }})
+            { _tag = "Exp_InitList", fields = {
+                { exp = { value = 40 } },
+                { exp = { value = 50 } },
+                { exp = { value = 60 } }, }})
     end)
 
     describe("can parse while statements", function()
@@ -562,7 +562,7 @@ describe("Titan parser", function()
         assert_expression_ast([[ f {} ]],
             { _tag = "Exp_Call", args = {
                 _tag = "Args_Func", args = {
-                    { _tag = "Exp_Table" } } } })
+                    { _tag = "Exp_InitList" } } } })
     end)
 
     it("can parse method calls without the optional parenthesis", function()
@@ -578,7 +578,7 @@ describe("Titan parser", function()
         assert_expression_ast([[ o:m {} ]],
             { _tag = "Exp_Call", args = {
                 _tag = "Args_Method", args = {
-                    { _tag = "Exp_Table" } } } })
+                    { _tag = "Exp_InitList" } } } })
     end)
 
     it("only allows call expressions as statements", function()
@@ -657,18 +657,15 @@ describe("Titan parser", function()
     end)
 
     it("can parse record constructors", function()
-        assert_expression_ast([[ Point.new(1.1, 2.2) ]],
-            { _tag = "Exp_Call",
-                args = { args = { { value = 1.1 }, { value = 2.2 } } },
-                exp = { var = {
-                    _tag = "Var_Dot",
-                    exp = { var = { name = "Point" } },
-                    name = "new" } } })
+        assert_expression_ast([[ { x = 1.1, y = 2.2 } ]],
+            { _tag = "Exp_InitList", fields = {
+                { name = "x", exp = { value = 1.1 } },
+                { name = "y", exp = { value = 2.2 } } }})
 
-        assert_expression_ast([[ List.new({}, nil) ]],
-            { _tag = "Exp_Call",
-                args = { args = { { _tag = "Exp_Table" }, { _tag = "Exp_Nil" } } } })
-
+        assert_expression_ast([[ { p = {}, next = nil } ]],
+            { _tag = "Exp_InitList", fields = {
+                { name = "p",    exp = { _tag = "Exp_InitList" } },
+                { name = "next", exp = { _tag = "Exp_Nil" } } }})
     end)
 
     it("can parse record field access", function()
@@ -946,7 +943,7 @@ describe("Titan parser", function()
 
         assert_expression_syntax_error([[ f(42,) ]], "ExpExpList")
 
-        assert_expression_syntax_error([[ y{42 ]], "RCurlyTableCons")
+        assert_expression_syntax_error([[ y{42 ]], "RCurlyInitList")
 
         assert_expression_syntax_error([[ y{42,,} ]], "ExpFieldList")
     end)

--- a/spec/parser_spec.lua
+++ b/spec/parser_spec.lua
@@ -711,11 +711,6 @@ describe("Titan parser", function()
         assert_statements_syntax_error([[ (x) = 42 ]], "ExpAssign")
     end)
 
-    it("does not allow mix array constructors and initalizer lists", function()
-        assert_expression_syntax_error([[ { x = 11, 22 } ]], "FieldFieldList")
-        assert_expression_syntax_error([[ { 11, y = 22 } ]], "RCurlyArrCons")
-    end)
-
     it("uses specific error labels for some errors", function()
 
         assert_program_syntax_error([[

--- a/spec/parser_spec.lua
+++ b/spec/parser_spec.lua
@@ -711,6 +711,11 @@ describe("Titan parser", function()
         assert_statements_syntax_error([[ (x) = 42 ]], "ExpAssign")
     end)
 
+    it("does not allow mix array constructors and initalizer lists", function()
+        assert_expression_syntax_error([[ { x = 11, 22 } ]], "FieldFieldList")
+        assert_expression_syntax_error([[ { 11, y = 22 } ]], "RCurlyArrCons")
+    end)
+
     it("uses specific error labels for some errors", function()
 
         assert_program_syntax_error([[

--- a/spec/parser_spec.lua
+++ b/spec/parser_spec.lua
@@ -666,6 +666,26 @@ describe("Titan parser", function()
             { _tag = "Exp_InitList", fields = {
                 { name = "p",    exp = { _tag = "Exp_InitList" } },
                 { name = "next", exp = { _tag = "Exp_Nil" } } }})
+
+        assert_expression_ast([[ Point.new(1.1, 2.2) ]],
+            { _tag = "Exp_Call",
+                args = { args = {
+                  { value = 1.1 },
+                  { value = 2.2 } } },
+                exp = { var = {
+                    _tag = "Var_Dot",
+                    exp = { var = { name = "Point" } },
+                    name = "new" } } })
+
+        assert_expression_ast([[ List.new({}, nil) ]],
+            { _tag = "Exp_Call",
+                args = { args = {
+                  { _tag = "Exp_InitList" },
+                  { _tag = "Exp_Nil" } } },
+                exp = { var = {
+                    _tag = "Var_Dot",
+                    exp = { var = { name = "List" } },
+                    name = "new" } } })
     end)
 
     it("can parse record field access", function()

--- a/titan-compiler/ast.lua
+++ b/titan-compiler/ast.lua
@@ -48,6 +48,7 @@ types.Exp = {
     Integer = {"value"},
     Float   = {"value"},
     String  = {"value"},
+    ArrCons = {"exps"},
     InitList= {"fields"},
     Call    = {"exp", "args"},
     Var     = {"var"},

--- a/titan-compiler/ast.lua
+++ b/titan-compiler/ast.lua
@@ -48,7 +48,7 @@ types.Exp = {
     Integer = {"value"},
     Float   = {"value"},
     String  = {"value"},
-    Table   = {"exps"},
+    InitList= {"fields"},
     Call    = {"exp", "args"},
     Var     = {"var"},
     Unop    = {"op", "exp"},
@@ -63,6 +63,10 @@ types.Exp = {
 types.Args = {
     Func    = {"args"},
     Method  = {"method", "args"},
+}
+
+types.Field = {
+    Field   = {"name", "exp"},
 }
 
 -- Create a function for each type constructor

--- a/titan-compiler/ast.lua
+++ b/titan-compiler/ast.lua
@@ -48,7 +48,6 @@ types.Exp = {
     Integer = {"value"},
     Float   = {"value"},
     String  = {"value"},
-    ArrCons = {"exps"},
     InitList= {"fields"},
     Call    = {"exp", "args"},
     Var     = {"var"},

--- a/titan-compiler/checker.lua
+++ b/titan-compiler/checker.lua
@@ -393,16 +393,18 @@ function checkexp(node, st, errors, context)
         node._type = types.Float
     elseif tag == "Exp_String" then
         node._type = types.String
-    elseif tag == "Exp_ArrCons" then
+    elseif tag == "Exp_InitList" then
         local econtext = context and context.elem
         local etypes = {}
-        for _, exp in ipairs(node.exps) do
+        for _, field in ipairs(node.fields) do
+            local exp = field.exp
             checkexp(exp, st, errors, econtext)
             table.insert(etypes, exp._type)
         end
         local etype = etypes[1] or (context and context.elem) or types.Integer
         node._type = types.Array(etype)
-        for i, exp in ipairs(node.exps) do
+        for i, field in ipairs(node.fields) do
+            local exp = field.exp
             checkmatch("array initializer at position " .. i, etype,
                        exp._type, errors, exp._pos)
         end

--- a/titan-compiler/checker.lua
+++ b/titan-compiler/checker.lua
@@ -393,17 +393,20 @@ function checkexp(node, st, errors, context)
         node._type = types.Float
     elseif tag == "Exp_String" then
         node._type = types.String
-    elseif tag == "Exp_Table" then
+    elseif tag == "Exp_InitList" then
         local econtext = context and context.elem
         local etypes = {}
-        for _, exp in ipairs(node.exps) do
+        for _, field in ipairs(node.fields) do
+            local exp = field.exp
             checkexp(exp, st, errors, econtext)
             table.insert(etypes, exp._type)
         end
         local etype = etypes[1] or (context and context.elem) or types.Integer
         node._type = types.Array(etype)
-        for i, exp in ipairs(node.exps) do
-            checkmatch("array initializer at position " .. i, etype, exp._type, errors, exp._pos)
+        for i, field in ipairs(node.fields) do
+            local exp = field.exp
+            checkmatch("array initializer at position " .. i, etype,
+                       exp._type, errors, exp._pos)
         end
     elseif tag == "Exp_Var" then
         checkexp(node.var, st, errors, context)

--- a/titan-compiler/checker.lua
+++ b/titan-compiler/checker.lua
@@ -393,18 +393,16 @@ function checkexp(node, st, errors, context)
         node._type = types.Float
     elseif tag == "Exp_String" then
         node._type = types.String
-    elseif tag == "Exp_InitList" then
+    elseif tag == "Exp_ArrCons" then
         local econtext = context and context.elem
         local etypes = {}
-        for _, field in ipairs(node.fields) do
-            local exp = field.exp
+        for _, exp in ipairs(node.exps) do
             checkexp(exp, st, errors, econtext)
             table.insert(etypes, exp._type)
         end
         local etype = etypes[1] or (context and context.elem) or types.Integer
         node._type = types.Array(etype)
-        for i, field in ipairs(node.fields) do
-            local exp = field.exp
+        for i, exp in ipairs(node.exps) do
             checkmatch("array initializer at position " .. i, etype,
                        exp._type, errors, exp._pos)
         end

--- a/titan-compiler/coder.lua
+++ b/titan-compiler/coder.lua
@@ -776,7 +776,8 @@ local function codetable(ctx, node, target)
     end
     table.insert(stats, cinit)
     local slots = {}
-    for _, exp in ipairs(node.exps) do
+    for _, field in ipairs(node.fields) do
+        local exp = field.exp
         local cstats, cexp = codeexp(ctx, exp)
         local ctmpe, tmpename, tmpeslot = newtmp(ctx, node._type.elem, true)
 
@@ -796,12 +797,12 @@ local function codetable(ctx, node, target)
         table.insert(slots, tmpeslot)
         table.insert(stats, code)
     end
-    if #node.exps > 0 then
+    if #node.fields > 0 then
         table.insert(stats, render([[
             luaH_resizearray(L, $TMPNAME, $SIZE);
         ]], {
             TMPNAME = tmpname,
-            SIZE = #node.exps
+            SIZE = #node.fields
         }))
 
     end
@@ -993,7 +994,7 @@ function codeexp(ctx, node, iscondition, target)
                 tag == "Exp_Float" or
                 tag == "Exp_String" then
             return codevalue(ctx, node, target)
-    elseif tag == "Exp_ArrCons" then
+    elseif tag == "Exp_InitList" then
             return codetable(ctx, node, target)
     elseif tag == "Exp_Var" then
         return codeexp(ctx, node.var, iscondition)

--- a/titan-compiler/coder.lua
+++ b/titan-compiler/coder.lua
@@ -776,7 +776,8 @@ local function codetable(ctx, node, target)
     end
     table.insert(stats, cinit)
     local slots = {}
-    for _, exp in ipairs(node.exps) do
+    for _, field in ipairs(node.fields) do
+        local exp = field.exp
         local cstats, cexp = codeexp(ctx, exp)
         local ctmpe, tmpename, tmpeslot = newtmp(ctx, node._type.elem, true)
 
@@ -796,12 +797,12 @@ local function codetable(ctx, node, target)
         table.insert(slots, tmpeslot)
         table.insert(stats, code)
     end
-    if #node.exps > 0 then
+    if #node.fields > 0 then
         table.insert(stats, render([[
             luaH_resizearray(L, $TMPNAME, $SIZE);
         ]], {
             TMPNAME = tmpname,
-            SIZE = #node.exps
+            SIZE = #node.fields
         }))
 
     end
@@ -993,7 +994,7 @@ function codeexp(ctx, node, iscondition, target)
                 tag == "Exp_Float" or
                 tag == "Exp_String" then
             return codevalue(ctx, node, target)
-    elseif tag == "Exp_Table" then
+    elseif tag == "Exp_InitList" then
             return codetable(ctx, node, target)
     elseif tag == "Exp_Var" then
         return codeexp(ctx, node.var, iscondition)

--- a/titan-compiler/coder.lua
+++ b/titan-compiler/coder.lua
@@ -776,8 +776,7 @@ local function codetable(ctx, node, target)
     end
     table.insert(stats, cinit)
     local slots = {}
-    for _, field in ipairs(node.fields) do
-        local exp = field.exp
+    for _, exp in ipairs(node.exps) do
         local cstats, cexp = codeexp(ctx, exp)
         local ctmpe, tmpename, tmpeslot = newtmp(ctx, node._type.elem, true)
 
@@ -797,12 +796,12 @@ local function codetable(ctx, node, target)
         table.insert(slots, tmpeslot)
         table.insert(stats, code)
     end
-    if #node.fields > 0 then
+    if #node.exps > 0 then
         table.insert(stats, render([[
             luaH_resizearray(L, $TMPNAME, $SIZE);
         ]], {
             TMPNAME = tmpname,
-            SIZE = #node.fields
+            SIZE = #node.exps
         }))
 
     end
@@ -994,7 +993,7 @@ function codeexp(ctx, node, iscondition, target)
                 tag == "Exp_Float" or
                 tag == "Exp_String" then
             return codevalue(ctx, node, target)
-    elseif tag == "Exp_InitList" then
+    elseif tag == "Exp_ArrCons" then
             return codetable(ctx, node, target)
     elseif tag == "Exp_Var" then
         return codeexp(ctx, node.var, iscondition)

--- a/titan-compiler/parser.lua
+++ b/titan-compiler/parser.lua
@@ -325,7 +325,7 @@ local grammar = re.compile([[
                      / ({} TRUE -> totrue)                       -> Exp_Bool
                      / ({} NUMBER)                               -> number_exp
                      / ({} STRING)                               -> Exp_String
-                     / tablecons                                 -- produces Exp
+                     / initlist                                  -- produces Exp
                      / suffixedexp                               -- produces Exp
                      / prefixexp                                 -- produces Exp
 
@@ -334,16 +334,21 @@ local grammar = re.compile([[
 
     funcargs        <- (LPAREN explist
                                (RPAREN / %{RParFuncArgs}))       -- produces {Exp}
-                     / {| tablecons |}                           -- produces {Exp}
+                     / {| initlist |}                            -- produces {Exp}
                      / {| ({} STRING) -> Exp_String |}           -- produces {Exp}
 
     explist         <- {| (exp (COMMA (exp / %{ExpExpList}))*)? |} -- produces {Exp}
 
-    tablecons       <- ({} LCURLY {| fieldlist? |}
-                                  (RCURLY / %{RCurlyTableCons})) -> Exp_Table
+    initlist        <- ({} LCURLY {| fieldlist? |}
+                                  (RCURLY / %{RCurlyInitList})) -> Exp_InitList
 
-    fieldlist       <- (exp (fieldsep (exp / !RCURLY %{ExpFieldList}))*
-                            fieldsep?)                           -- produces Exp...
+    fieldlist       <- (field
+                        (fieldsep
+                         (field /
+                          !RCURLY %{ExpFieldList}))*
+                        fieldsep?)                          -- produces Field...
+
+    field           <- ({} (NAME ASSIGN)? -> opt exp)       -> Field_Field
 
     fieldsep        <- SEMICOLON / COMMA
 

--- a/titan-compiler/parser.lua
+++ b/titan-compiler/parser.lua
@@ -326,7 +326,6 @@ local grammar = re.compile([[
                      / ({} NUMBER)                               -> number_exp
                      / ({} STRING)                               -> Exp_String
                      / initlist                                  -- produces Exp
-                     / arrcons                                   -- produces Exp
                      / suffixedexp                               -- produces Exp
                      / prefixexp                                 -- produces Exp
 
@@ -336,24 +335,20 @@ local grammar = re.compile([[
     funcargs        <- (LPAREN explist
                                (RPAREN / %{RParFuncArgs}))       -- produces {Exp}
                      / {| initlist |}                            -- produces {Exp}
-                     / {| arrcons |}                             -- produces {Exp}
                      / {| ({} STRING) -> Exp_String |}           -- produces {Exp}
 
     explist         <- {| (exp (COMMA (exp / %{ExpExpList}))*)? |} -- produces {Exp}
 
-    arrcons         <- ({} LCURLY {| arrexplist? |}
-                        (RCURLY / %{RCurlyArrCons}))            -> Exp_ArrCons
+    initlist        <- ({} LCURLY {| fieldlist? |}
+                                  (RCURLY / %{RCurlyInitList})) -> Exp_InitList
 
-    arrexplist      <- (exp (fieldsep (exp / !RCURLY %{ExpArrList}))*
-                        fieldsep?)                              -- produces exp...
+    fieldlist       <- (field
+                        (fieldsep
+                         (field /
+                          !RCURLY %{ExpFieldList}))*
+                        fieldsep?)                          -- produces Field...
 
-    initlist        <- ({} LCURLY {| fieldlist |}
-                        (RCURLY / %{RCurlyInitList}))           -> Exp_InitList
-
-    fieldlist       <- (field (fieldsep (field / !RCURLY %{FieldFieldList}))*
-                        fieldsep?)                              -- produces Field...
-
-    field           <- ({} NAME ASSIGN exp)                     -> Field_Field
+    field           <- ({} (NAME ASSIGN)? -> opt exp)       -> Field_Field
 
     fieldsep        <- SEMICOLON / COMMA
 

--- a/titan-compiler/syntax_errors.lua
+++ b/titan-compiler/syntax_errors.lua
@@ -219,11 +219,17 @@ local errors = {
     { label = "ExpExpList",
         msg = "Expected an expression after ','." },
 
+    { label = "RCurlyArrCons",
+        msg = "Expected '{' to match '}'." },
+
+    { label = "ExpArrList",
+        msg = "Expected an expression after ',' or ';'." },
+
     { label = "RCurlyInitList",
         msg = "Expected '{' to match '}'." },
 
-    { label = "ExpFieldList",
-        msg = "Expected an expression after ',' or ';'." },
+    { label = "FieldFieldList",
+        msg = "Expected an field initialization after ',' or ';'." },
 
     { label = "ExpStat",
         msg = "Expected a statement but found an expression that is not a function call"},

--- a/titan-compiler/syntax_errors.lua
+++ b/titan-compiler/syntax_errors.lua
@@ -219,17 +219,11 @@ local errors = {
     { label = "ExpExpList",
         msg = "Expected an expression after ','." },
 
-    { label = "RCurlyArrCons",
-        msg = "Expected '{' to match '}'." },
-
-    { label = "ExpArrList",
-        msg = "Expected an expression after ',' or ';'." },
-
     { label = "RCurlyInitList",
         msg = "Expected '{' to match '}'." },
 
-    { label = "FieldFieldList",
-        msg = "Expected an field initialization after ',' or ';'." },
+    { label = "ExpFieldList",
+        msg = "Expected an expression after ',' or ';'." },
 
     { label = "ExpStat",
         msg = "Expected a statement but found an expression that is not a function call"},

--- a/titan-compiler/syntax_errors.lua
+++ b/titan-compiler/syntax_errors.lua
@@ -219,7 +219,7 @@ local errors = {
     { label = "ExpExpList",
         msg = "Expected an expression after ','." },
 
-    { label = "RCurlyTableCons",
+    { label = "RCurlyInitList",
         msg = "Expected '{' to match '}'." },
 
     { label = "ExpFieldList",

--- a/titan-compiler/types.lua
+++ b/titan-compiler/types.lua
@@ -9,6 +9,10 @@ function types.Array(etype)
     return { _tag = "Array", elem = etype }
 end
 
+function types.InitList(elems)
+    return { _tag = "InitList", elems = elems }
+end
+
 function types.Module(modname, members)
     return { _tag = "Module", name = modname,
         prefix = modname:gsub("[.]", "_") .. "_",


### PR DESCRIPTION
This is a proposal to change the syntax to create records.
This also have a impact on arrays, since `local x = {}` will be an error instead of an array of integers.
See the modifications in the manual for more details.