### PR TITLE
Fixes some parser issues

### DIFF
--- a/titan-compiler/syntax_errors.lua
+++ b/titan-compiler/syntax_errors.lua
@@ -227,6 +227,12 @@ local errors = {
     { label = "ExpFieldList",
         msg = "Expected an expression after ',' or ';'." },
 
+    { label = "ExpStat",
+        msg = "Expected a statement but found an expression that is not a function call"},
+
+    { label = "ExpAssign",
+        msg = "Expected a valid lvalue in the left side of assignment but found a regular expression" }
+
 }
 
 syntax_errors.label_to_msg = {}


### PR DESCRIPTION
Clears some pending test cases involving treatment of lvalues and suffixed expressions, fixes #79 , also fixes some edge cases (we were allowing things like `true.foo` and `{}.foo` that are syntactically invalid in Lua).