### PR TITLE
Add tests for method call syntax errors

### DIFF
--- a/spec/parser_spec.lua
+++ b/spec/parser_spec.lua
@@ -928,6 +928,10 @@ describe("Titan parser", function()
 
         assert_expression_syntax_error([[ 1 + ]], "OpExp")
 
+        assert_expression_syntax_error([[ obj:() ]], "NameColonExpSuf")
+
+        assert_expression_syntax_error([[ obj:f + 1 ]], "FuncArgsExpSuf")
+
         assert_expression_syntax_error([[ y[] ]], "ExpExpSuf")
 
         assert_expression_syntax_error([[ y[1 ]], "RBracketExpSuf")

--- a/titan-compiler/syntax_errors.lua
+++ b/titan-compiler/syntax_errors.lua
@@ -192,11 +192,9 @@ local errors = {
     { label = "OpExp",
         msg = "Expected an expression after operator." },
 
-   -- not used currently because the parser rule is commented
     { label = "NameColonExpSuf",
         msg = "Expected a method name after ':'." },
 
-   -- not used currently because the parser rule is commented
     { label = "FuncArgsExpSuf",
         msg = "Expected a list of arguments." },
 


### PR DESCRIPTION
Now that the method call syntax is working again we can add these tests back in. Fixes #74