### PR TITLE
Making Titan compile on Mac OS X

### DIFF
--- a/spec/coder_spec.lua
+++ b/spec/coder_spec.lua
@@ -17,8 +17,8 @@ local function generate(ast, modname)
     local CFLAGS = "--std=c99 -O2 -Wall -Ilua/src/ -fPIC"
 
     local cc_cmd = string.format([[
-        %s %s -shared %s.c -o %s.so
-        ]], CC, CFLAGS, modname, modname)
+        %s %s %s %s.c -o %s.so
+        ]], CC, CFLAGS, driver.shared(), modname, modname)
     return os.execute(cc_cmd)
 end
 

--- a/titan-compiler/driver.lua
+++ b/titan-compiler/driver.lua
@@ -105,7 +105,7 @@ function driver.compile_module(CC, CFLAGS, modname, mod)
     os.remove(soname)
     local ok, err = util.set_file_contents(filename, code)
     if not ok then return nil, err end
-      local cc_cmd = string.format([[
+    local cc_cmd = string.format([[
         %s %s %s %s -o %s
         ]], CC, CFLAGS, driver.shared(), filename, soname)
     --print(cc_cmd)

--- a/titan-compiler/driver.lua
+++ b/titan-compiler/driver.lua
@@ -86,6 +86,15 @@ function driver.tableloader(modtable, imported)
     return loader
 end
 
+function driver.shared()
+    local shared = "-shared"
+    local uname = io.popen("uname"):read("*a")
+    if string.match(uname, "Darwin") then
+        shared = shared .. " -undefined dynamic_lookup"
+    end
+    return shared
+end
+
 function driver.compile_module(CC, CFLAGS, modname, mod)
     if mod.compiled then return true end
     local code = coder.generate(modname, mod.ast)
@@ -96,9 +105,9 @@ function driver.compile_module(CC, CFLAGS, modname, mod)
     os.remove(soname)
     local ok, err = util.set_file_contents(filename, code)
     if not ok then return nil, err end
-    local cc_cmd = string.format([[
-        %s %s -shared %s -o %s
-        ]], CC, CFLAGS, filename, soname)
+      local cc_cmd = string.format([[
+        %s %s %s %s -o %s
+        ]], CC, CFLAGS, driver.shared(), filename, soname)
     --print(cc_cmd)
     local ok, err = os.execute(cc_cmd)
     if not ok then return nil, err end


### PR DESCRIPTION
It looks like that latest clang update broke some compatibility with gcc. Under Mac OS X I cannot compile the following example:
```
function f (x:integer): integer
    return x + 1
end
```
as it will give me the following error message:
```
$ ./titanc t
./t.c:22:24: warning: unused function '_integer2str' [-Wunused-function]
inline static TString* _integer2str (lua_State *L, lua_Integer i) {
                       ^
./t.c:28:24: warning: unused function '_float2str' [-Wunused-function]
inline static TString* _float2str (lua_State *L, lua_Number f) {
                       ^
2 warnings generated.
Undefined symbols for architecture x86_64:
  "_luaL_error", referenced from:
      _f_lua in t-bdf40c.o
  "_luaL_setmetatable", referenced from:
      _luaopen_t in t-bdf40c.o
  "_lua_createtable", referenced from:
      _luaopen_t in t-bdf40c.o
  "_lua_pushcclosure", referenced from:
      _luaopen_t in t-bdf40c.o
  "_lua_pushstring", referenced from:
      _t_types in t-bdf40c.o
  "_lua_setfield", referenced from:
      _luaopen_t in t-bdf40c.o
  "_lua_typename", referenced from:
      _f_lua in t-bdf40c.o
ld: symbol(s) not found for architecture x86_64
clang: error: linker command failed with exit code 1 (use -v to see invocation)
exit
```
This happens when running gcc with the following command line:
```
gcc --std=c99 -O2 -Wall -Ilua/src/ -fPIC -shared ./t.c -o ./t.so
```
This is fine on Linux, but on Mac OS X we will have to use something like this:
```
gcc --std=c99 -O2 -Wall -Ilua/src/ -fPIC -shared -undefined dynamic_lookup ./t.c -o ./t.so
```
This PR checks whether TItan is running under Mac OS X and adjusts the gcc command line accordingly.

Can we please include this patch so I can get back to work? 😊 