### PR TITLE
Use semicolon as an optional field separator for records

### DIFF
--- a/doc/manual.md
+++ b/doc/manual.md
@@ -56,9 +56,9 @@ return values for functions.
 
 ### Records
 
-Records types in Titan are nominal and should be declared in the top level,
-following the syntax `record Type (field: type)* end`. The following example
-declare a record `Point` with the fields `x` and `y` which are floats.
+Records types in Titan are nominal and should be declared in the top level.
+The following example declare a record `Point` with the fields `x` and `y`
+which are floats.
 
     record Point
         x: float
@@ -67,7 +67,7 @@ declare a record `Point` with the fields `x` and `y` which are floats.
 
 You can create records with initializer lists or using the `new` constructor.
 When using initializer lists, you must assign a value to each field of the
-record with the syntax `{ (field = value)* }`.
+record.
 The `Type.new()` constructor is automatically declared and receive a parameter
 for each field in the order they were declared.
 For instance, you could initialize an instance of the record `Point` with:
@@ -251,7 +251,7 @@ Here is the complete syntax of Titan in extended BNF. As usual in extended BNF, 
 
     recordfields ::= recordfield {recordfield}
 
-    recordfield ::= Name ':' type
+    recordfield ::= Name ':' type [';']
 
     block ::= {stat} [retstat]
 

--- a/spec/parser_spec.lua
+++ b/spec/parser_spec.lua
@@ -643,8 +643,8 @@ describe("Titan parser", function()
 
         assert_program_ast([[
             record List
-                p: {Point};
-                next: List;
+                p: {Point}
+                next: List
             end
         ]], {
             { _tag = "TopLevel_Record",
@@ -654,6 +654,26 @@ describe("Titan parser", function()
                   type = { subtype = { name = "Point" } } },
                 { name = "next", type = { name = "List" } } } },
         })
+    end)
+
+    it("can parse the record field optional separator", function()
+        local ast = {{ fields = { { name = "x" }, { name = "y" } } }}
+
+        assert_program_ast([[
+            record Point x: float y: float end
+        ]], ast)
+
+        assert_program_ast([[
+            record Point x: float; y: float end
+        ]], ast)
+
+        assert_program_ast([[
+            record Point x: float y: float; end
+        ]], ast)
+
+        assert_program_ast([[
+            record Point x: float; y: float; end
+        ]], ast)
     end)
 
     it("can parse record constructors", function()

--- a/spec/parser_spec.lua
+++ b/spec/parser_spec.lua
@@ -643,8 +643,8 @@ describe("Titan parser", function()
 
         assert_program_ast([[
             record List
-                p: {Point}
-                next: List
+                p: {Point};
+                next: List;
             end
         ]], {
             { _tag = "TopLevel_Record",

--- a/titan-compiler/parser.lua
+++ b/titan-compiler/parser.lua
@@ -243,8 +243,10 @@ local grammar = re.compile([[
 
     recordfields    <- {| recordfield+ |}                        -- produces {Decl}
 
-    recordfield     <- ({} NAME (COLON / %{ColonRecordField})
-                               (type / %{TypeRecordField}))      -> Decl_Decl
+    recordfield     <- ({} NAME
+                           (COLON / %{ColonRecordField})
+                           (type / %{TypeRecordField})
+                           SEMICOLON?)                      -> Decl_Decl
 
     block           <- ({} {| statement* returnstat? |})         -> Stat_Block
 


### PR DESCRIPTION
Example:
```
record point
    x: float; y: float
end
```