### PR TITLE
Remove special cases from string coersions

### DIFF
--- a/spec/checker_spec.lua
+++ b/spec/checker_spec.lua
@@ -212,12 +212,12 @@ describe("Titan type checker", function()
             function fn()
                 local i: integer = 1
                 local s: string = "foo"
-                s = i
+                i = s
             end
         ]]
         local ok, err = run_checker(code)
         assert.falsy(ok)
-        assert.match("expected string but found integer", err)
+        assert.match("expected integer but found string", err)
     end)
 
     it("function can call another function", function()
@@ -236,12 +236,12 @@ describe("Titan type checker", function()
     it("catches mismatching types in arguments", function()
         local code = [[
             function fn(i: integer, s: string): integer
-                s = i
+                i = s
             end
         ]]
         local ok, err = run_checker(code)
         assert.falsy(ok)
-        assert.match("expected string but found integer", err)
+        assert.match("expected integer but found string", err)
     end)
 
     it("allows setting element of array as nil", function ()
@@ -330,14 +330,14 @@ describe("Titan type checker", function()
             function fn(x: integer): integer
                 local i: integer = 15
                 while i do
-                    local s: string = i
+                    local a: integer = "a"
                 end
                 return x
             end
         ]]
         local ok, err = run_checker(code)
         assert.falsy(ok)
-        assert.match("expected string but found integer", err)
+        assert.match("expected integer but found string", err)
     end)
 
     it("type-checks 'for' with a step", function()
@@ -633,7 +633,7 @@ describe("Titan type checker", function()
         assert.match("cannot concatenate with boolean value", err)
     end)
 
-    it("cannot concatenate with type value", function()
+    it("can concatenate with type value", function()
         local code = [[
             function fn()
                 local v: value = "bar"
@@ -641,8 +641,7 @@ describe("Titan type checker", function()
             end
         ]]
         local ok, err = run_checker(code)
-        assert.falsy(ok)
-        assert.match("cannot concatenate with value", err)
+        assert.truthy(ok)
     end)
 
     it("can concatenate with integer and float", function()
@@ -996,7 +995,7 @@ describe("Titan type checker", function()
     it("uses module variable with wrong type", function ()
         local modules = {
             foo = [[
-                a: integer = 1
+                a: {integer} = {}
             ]],
             bar = [[
                 local foo = import "foo"
@@ -1008,8 +1007,8 @@ describe("Titan type checker", function()
         }
         local ok, err, mods = run_checker_modules(modules, "bar")
         assert.falsy(ok)
-        assert.match("expected string but found integer", err)
-        assert.match("expected integer but found string", err)
+        assert.match("expected { integer } but found string", err)
+        assert.match("expected string but found { integer }", err)
     end)
 
     it("catches module variable initialization with wrong type", function()
@@ -1135,7 +1134,7 @@ describe("Titan type checker", function()
     it("uses module variable with wrong type", function ()
         local modules = {
             foo = [[
-                a: integer = 1
+                a: {integer} = {}
             ]],
             bar = [[
                 local foo = import "foo"
@@ -1147,8 +1146,8 @@ describe("Titan type checker", function()
         }
         local ok, err, mods = run_checker_modules(modules, "bar")
         assert.falsy(ok)
-        assert.match("expected string but found integer", err)
-        assert.match("expected integer but found string", err)
+        assert.match("expected { integer } but found string", err)
+        assert.match("expected string but found { integer }", err)
     end)
 
     it("catches module variable initialization with wrong type", function()

--- a/spec/coder_spec.lua
+++ b/spec/coder_spec.lua
@@ -713,6 +713,41 @@ describe("Titan code generator", function()
         assert.truthy(ok, err)
     end)
 
+    it("generate code for string coercion from value", function()
+        local code = [[
+            function concat(a: string): string
+                local v: value = a
+                return v .. 2.5
+            end
+        ]]
+        local ast, err = parser.parse(code)
+        assert.truthy(ast, err)
+        local ok, err = checker.check("test", ast, code, "test.titan")
+        assert.truthy(ok, err)
+        local ok, err = generate(ast, "titan_test")
+        assert.truthy(ok, err)
+        local ok, err = call("titan_test", "assert(titan_test.concat('a') == 'a2.5')")
+        assert.truthy(ok, err)
+    end)
+
+    it("generate code for string coercion from integer/float value", function()
+        local code = [[
+            function concat(a: integer, b: float): string
+                local x: value = a
+                local y: value = b
+                return x .. y
+            end
+        ]]
+        local ast, err = parser.parse(code)
+        assert.truthy(ast, err)
+        local ok, err = checker.check("test", ast, code, "test.titan")
+        assert.truthy(ok, err)
+        local ok, err = generate(ast, "titan_test")
+        assert.truthy(ok, err)
+        local ok, err = call("titan_test", "assert(titan_test.concat(123, 4.5) == '1234.5')")
+        assert.truthy(ok, err)
+    end)
+
     it("generates code for string concatenation of several strings", function()
         local code = [[
             function concat(a: string, b: string, c: string, d: string, e: string): string
@@ -885,7 +920,7 @@ describe("Titan code generator", function()
     local valfailures = {
         integer = "'foo'",
         float = "'foo'",
-        string = 2,
+        string = false,
         ["nil"] = 0,
         table = { type = "{integer}", val = "10" }
     }

--- a/titan-compiler/checker.lua
+++ b/titan-compiler/checker.lua
@@ -10,11 +10,10 @@ local checkexp
 
 local function typeerror(errors, msg, pos, ...)
     local l, c = util.get_line_number(errors.subject, pos)
-    msg = string.format("%s:%d:%d: type error: %s", errors.filename, l, c, string.format(msg, ...))
+    msg = string.format("%s:%d:%d: type error: %s", errors.filename, l, c,
+                        string.format(msg, ...))
     table.insert(errors, msg)
 end
-
-checker.typeerror = typeerror
 
 -- Checks if two types are the same, and logs an error message otherwise
 --   term: string describing what is being compared
@@ -75,18 +74,6 @@ local function trycoerce(node, target, errors)
         local l, _ = util.get_line_number(errors.subject, n._pos)
         n._lin = l
         n._type = target
-        return n
-    else
-        return node
-    end
-end
-
-local function trytostr(node)
-    local source = node._type
-    if types.equals(source, types.Integer) or
-      types.equals(source, types.Float) then
-        local n = ast.Exp_Cast(node._pos, node, types.String)
-        n._type = types.String
         return n
     else
         return node
@@ -377,7 +364,7 @@ function checkexp(node, st, errors, context)
         for i, exp in ipairs(node.exps) do
             checkexp(exp, st, errors, types.String)
             -- always tries to coerce numbers to string
-            exp = trytostr(exp)
+            exp = trycoerce(exp, types.String, errors)
             node.exps[i] = exp
             local texp = exp._type
             if types.equals(texp, types.Value) then

--- a/titan-compiler/coder.lua
+++ b/titan-compiler/coder.lua
@@ -120,8 +120,27 @@ local function checkandget(typ --[[:table]], cvar --[[:string]], exp --[[:string
             VAR = cvar
         })
     elseif types.equals(typ, types.Nil) then tag = "nil"
+        -- fallthrough
     elseif types.equals(typ, types.String) then tag = "string"
+        return render([[
+            if (TITAN_LIKELY(ttisstring($EXP))) {
+                $GETSLOT;
+            } else if (ttisinteger($EXP)) {
+                $VAR = _integer2str(L, ivalue($EXP));
+            } else if (ttisfloat($EXP)) {
+                $VAR = _float2str(L, fltvalue($EXP));
+            } else {
+                luaL_error(L, "type error at line %d, expected string but "
+                           "found %s", $LINE, lua_typename(L, ttnov($EXP)));
+            }
+        ]], {
+            EXP = exp,
+            GETSLOT = getslot(typ, cvar, exp),
+            VAR = cvar,
+            LINE = c_integer_literal(line),
+        })
     elseif types.has_tag(typ, "Array") then tag = "table"
+        -- fallthrough
     elseif types.equals(typ, types.Value) then
         return render([[
             setobj2t(L, &$VAR, $EXP);

--- a/titan-compiler/types.lua
+++ b/titan-compiler/types.lua
@@ -44,6 +44,10 @@ function types.coerceable(source, target)
             types.equals(target, types.Float)) or
            (types.equals(source, types.Float) and
             types.equals(target, types.Integer)) or
+           (types.equals(source, types.Float) and
+            types.equals(target, types.String)) or
+           (types.equals(source, types.Integer) and
+            types.equals(target, types.String)) or
            (types.equals(target, types.Boolean) and
             not types.equals(source, types.Boolean)) or
            (types.equals(target, types.Value) and


### PR DESCRIPTION
Now concat will accept any value that can coerce to a string and numbers can be coersed to strings in any place.

The following code wasn't valid (now it should be):
```
function problem1(v: value)
    local s: string = v
    local s1: string = v .. v -- type error
    local s2: string = s .. s -- worked
end
function problem2(i: integer)
    local s1: string = i -- type error
    local s2: string = "" .. i -- worked
end
``` 