### PR TITLE
Adding more tests to type checker and fixing LPegLabel dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ this will also install all dependencies automatically.
 
 # Requirements for running the compiler
 
-1. [LPegLabel](https://github.com/sqmedeiros/lpeglabel) >= 1.0.0
+1. [LPegLabel](https://github.com/sqmedeiros/lpeglabel) >= 1.0.0, < 1.5.0
 2. [inspect](https://github.com/kikito/inspect.lua) >= 3.1.0
 3. [argparse](https://github.com/mpeterv/argparse) >= 0.5.0
 4. [luafilesystem](https://github.com/keplerproject/luafilesystem) >= 1.7.0

--- a/spec/checker_spec.lua
+++ b/spec/checker_spec.lua
@@ -959,6 +959,95 @@ describe("Titan type checker", function()
         end
     end
 
+    for _, t in ipairs({"{integer}", "boolean", "float", "integer", "nil", "string"}) do
+        it("can explicitly cast from value to " .. t, function()
+            local code = [[
+                function fn(a: value): ]] .. t .. [[
+                    return a as ]] .. t .. [[
+                end
+            ]]
+            local ok, err = run_checker(code)
+            assert.truthy(ok)
+        end)
+    end
+
+    for _, t in ipairs({"{integer}", "boolean", "float", "integer", "nil", "string"}) do
+        it("can explicitly cast from " .. t .. "to value", function()
+            local code = [[
+                function fn(a: ]] .. t .. [[): value 
+                    return a as value
+                end
+            ]]
+            local ok, err = run_checker(code)
+            assert.truthy(ok)
+        end)
+    end
+
+    for _, t in ipairs({"boolean", "float", "integer", "nil", "string"}) do
+        it("cannot explicitly cast from " .. t .. " to {integer}", function()
+            local code = [[
+                function fn(a: ]] .. t .. [[): {integer} 
+                    return a as {integer}
+                end
+            ]]
+            local ok, err = run_checker(code)
+            assert.falsy(ok)
+            assert.match("cannot cast", err)
+        end)
+    end
+
+    for _, t in ipairs({"{integer}", "boolean", "integer", "nil", "string"}) do
+        it("cannot explicitly cast from " .. t .. " to float", function()
+            local code = [[
+                function fn(a: ]] .. t .. [[): float 
+                    return a as float
+                end
+            ]]
+            local ok, err = run_checker(code)
+            assert.falsy(ok)
+            assert.match("cannot cast", err)
+        end)
+    end
+
+    for _, t in ipairs({"{integer}", "boolean", "nil", "string"}) do
+        it("cannot explicitly cast from " .. t .. " to integer", function()
+            local code = [[
+                function fn(a: ]] .. t .. [[): integer 
+                    return a as integer
+                end
+            ]]
+            local ok, err = run_checker(code)
+            assert.falsy(ok)
+            assert.match("cannot cast", err)
+        end)
+    end
+
+    for _, t in ipairs({"{integer}", "boolean", "float", "integer", "string"}) do
+        it("cannot explicitly cast from " .. t .. " to nil", function()
+            local code = [[
+                function fn(a: ]] .. t .. [[): nil
+                    return a as nil
+                end
+            ]]
+            local ok, err = run_checker(code)
+            assert.falsy(ok)
+            assert.match("cannot cast", err)
+        end)
+    end
+
+    for _, t in ipairs({"{integer}", "boolean", "nil"}) do
+        it("cannot explicitly cast from " .. t .. " to string", function()
+            local code = [[
+                function fn(a: ]] .. t .. [[): string
+                    return a as string
+                end
+            ]]
+            local ok, err = run_checker(code)
+            assert.falsy(ok)
+            assert.match("cannot cast", err)
+        end)
+    end
+
     it("returns the type of the module with exported members", function()
         local modules = { test = [[
             a: integer = 1

--- a/titan-dev-1.rockspec
+++ b/titan-dev-1.rockspec
@@ -15,7 +15,7 @@ description = {
 }
 dependencies = {
    "lua ~> 5.3",
-   "lpeglabel >= 1.0.0",
+   "lpeglabel >= 1.0.0, < 1.5.0",
    "inspect >= 3.1.0",
    "argparse >= 0.5.0",
    "luafilesystem >= 1.7.0"


### PR DESCRIPTION
This PR adds more tests to the type checker. It adds tests to logical and bitwise operators as well as explicit casts. While I was committing the changes Travis CI broke to run the tests and I noticed that the problem was with LPegLabel version 1.5.0 (the latest version). For this reason this PR also fixes the rockspec and README to require LPegLabel `>= 1.0.0`,  but `< 1.5.0`.