### PR TITLE
Add a "." separator to datatype tags

### DIFF
--- a/spec/checker_spec.lua
+++ b/spec/checker_spec.lua
@@ -75,8 +75,8 @@ describe("Titan type checker", function()
         ]]
         local ok, err, ast = run_checker(code)
         assert.truthy(ok)
-        assert.same("AstExpCast", ast[1].block.stats[2].exp._tag)
-        assert.same("TypeInteger", ast[1].block.stats[2].exp.target._tag)
+        assert.same("Ast.ExpCast", ast[1].block.stats[2].exp._tag)
+        assert.same("Type.Integer", ast[1].block.stats[2].exp.target._tag)
     end)
 
     it("coerces to float", function()
@@ -89,8 +89,8 @@ describe("Titan type checker", function()
         ]]
         local ok, err, ast = run_checker(code)
         assert.truthy(ok)
-        assert.same("AstExpCast", ast[1].block.stats[2].exp._tag)
-        assert.same("TypeFloat", ast[1].block.stats[2].exp.target._tag)
+        assert.same("Ast.ExpCast", ast[1].block.stats[2].exp._tag)
+        assert.same("Type.Float", ast[1].block.stats[2].exp.target._tag)
     end)
 
     it("catches duplicate function declarations", function()
@@ -1070,11 +1070,11 @@ describe("Titan type checker", function()
         local ok, err, mods = run_checker_modules(modules, "test")
         assert.truthy(ok)
         assert_ast(mods.test.type, {
-            _tag = "TypeModule",
+            _tag = "Type.Module",
             name = "test",
             members = {
-                a = { _tag = "TypeInteger" },
-                geta = { _tag = "TypeFunction" }
+                a = { _tag = "Type.Integer" },
+                geta = { _tag = "Type.Function" }
             }
         })
         assert.falsy(mods.test.type.members.b)
@@ -1106,11 +1106,11 @@ describe("Titan type checker", function()
         assert.truthy(ok)
         assert.truthy(mods.foo)
         assert_ast(mods.foo.type, {
-            _tag = "TypeModule",
+            _tag = "Type.Module",
             name = "foo",
             members = {
-                a = { _tag = "TypeInteger" },
-                foo = { _tag = "TypeFunction" }
+                a = { _tag = "Type.Integer" },
+                foo = { _tag = "Type.Function" }
             }
         })
     end)

--- a/spec/parser_spec.lua
+++ b/spec/parser_spec.lua
@@ -141,13 +141,13 @@ describe("Titan parser", function()
 
     it("can parse toplevel var declarations", function()
         assert_program_ast([[ local x=17 ]], {
-            { _tag = "AstTopLevelVar",
+            { _tag = "Ast.TopLevelVar",
                 islocal = true,
                 decl = { name = "x", type = false } }
         })
 
         assert_program_ast([[ y = 18 ]], {
-            { _tag = "AstTopLevelVar",
+            { _tag = "Ast.TopLevelVar",
                 islocal = false,
                 decl = { name = "y", type = false } }
         })
@@ -158,38 +158,38 @@ describe("Titan parser", function()
             local function fA(): nil
             end
         ]], {
-            { _tag = "AstTopLevelFunc",
+            { _tag = "Ast.TopLevelFunc",
                 islocal = true,
                 name = "fA",
                 params = {},
-                block = { _tag = "AstStatBlock", stats = {} } },
+                block = { _tag = "Ast.StatBlock", stats = {} } },
         })
 
         assert_program_ast([[
             local function fB(x:int): nil
             end
         ]], {
-            { _tag = "AstTopLevelFunc",
+            { _tag = "Ast.TopLevelFunc",
                 islocal = true,
                 name = "fB",
                 params = {
-                    { _tag = "AstDecl", name = "x" },
+                    { _tag = "Ast.Decl", name = "x" },
                 },
-                block = { _tag = "AstStatBlock", stats = {} } },
+                block = { _tag = "Ast.StatBlock", stats = {} } },
         })
 
         assert_program_ast([[
             local function fC(x:int, y:int): nil
             end
         ]], {
-            { _tag = "AstTopLevelFunc",
+            { _tag = "Ast.TopLevelFunc",
                 islocal = true,
                 name = "fC",
                 params = {
-                    { _tag = "AstDecl", name = "x" },
-                    { _tag = "AstDecl", name = "y" },
+                    { _tag = "Ast.Decl", name = "x" },
+                    { _tag = "Ast.Decl", name = "y" },
                 },
-                block = { _tag = "AstStatBlock", stats = {} } },
+                block = { _tag = "Ast.StatBlock", stats = {} } },
         })
     end)
 
@@ -200,83 +200,83 @@ describe("Titan parser", function()
             local function bar()
             end
         ]], {
-            { _tag = "AstTopLevelFunc", name = "foo", rettypes = { { _tag = "AstTypeNil" } } },
-            { _tag = "AstTopLevelFunc", name = "bar", rettypes = { { _tag = "AstTypeNil" } } },
+            { _tag = "Ast.TopLevelFunc", name = "foo", rettypes = { { _tag = "Ast.TypeNil" } } },
+            { _tag = "Ast.TopLevelFunc", name = "bar", rettypes = { { _tag = "Ast.TypeNil" } } },
         })
     end)
 
     it("can parse primitive types", function()
-        assert_type_ast("nil", { _tag = "AstTypeNil" } )
-        assert_type_ast("int", { _tag = "AstTypeName", name = "int" } )
+        assert_type_ast("nil", { _tag = "Ast.TypeNil" } )
+        assert_type_ast("int", { _tag = "Ast.TypeName", name = "int" } )
     end)
 
     it("can parse array types", function()
         assert_type_ast("{int}",
-            { _tag = "AstTypeArray", subtype =
-                {_tag = "AstTypeName", name = "int" } } )
+            { _tag = "Ast.TypeArray", subtype =
+                {_tag = "Ast.TypeName", name = "int" } } )
 
         assert_type_ast("{{int}}",
-            { _tag = "AstTypeArray", subtype =
-                { _tag = "AstTypeArray", subtype =
-                    {_tag = "AstTypeName", name = "int" } } } )
+            { _tag = "Ast.TypeArray", subtype =
+                { _tag = "Ast.TypeArray", subtype =
+                    {_tag = "Ast.TypeName", name = "int" } } } )
     end)
 
     describe("can parse function types", function()
         it("with parameter lists of length = 0", function()
             assert_type_ast("() -> ()",
-                { _tag = "AstTypeFunction",
+                { _tag = "Ast.TypeFunction",
                     argtypes = { },
                     rettypes = { } } )
         end)
 
         it("with parameter lists of length = 1", function()
             assert_type_ast("(a) -> (b)",
-                { _tag = "AstTypeFunction",
-                    argtypes = { { _tag = "AstTypeName", name = "a" } },
-                    rettypes = { { _tag = "AstTypeName", name = "b" } } } )
+                { _tag = "Ast.TypeFunction",
+                    argtypes = { { _tag = "Ast.TypeName", name = "a" } },
+                    rettypes = { { _tag = "Ast.TypeName", name = "b" } } } )
         end)
 
         it("with parameter lists of length >= 2 ", function()
             assert_type_ast("(a,b) -> (c,d,e)",
-                { _tag = "AstTypeFunction",
+                { _tag = "Ast.TypeFunction",
                     argtypes = {
-                        { _tag = "AstTypeName", name = "a" },
-                        { _tag = "AstTypeName", name = "b" },
+                        { _tag = "Ast.TypeName", name = "a" },
+                        { _tag = "Ast.TypeName", name = "b" },
                     },
                     rettypes = {
-                        { _tag = "AstTypeName", name = "c" },
-                        { _tag = "AstTypeName", name = "d" },
-                        { _tag = "AstTypeName", name = "e" },
+                        { _tag = "Ast.TypeName", name = "c" },
+                        { _tag = "Ast.TypeName", name = "d" },
+                        { _tag = "Ast.TypeName", name = "e" },
                     }
                  })
         end)
 
         it("without the optional parenthesis", function()
             assert_type_ast("a -> b",
-                { _tag = "AstTypeFunction",
-                    argtypes = { { _tag = "AstTypeName", name = "a" } },
-                    rettypes = { { _tag = "AstTypeName", name = "b" } } } )
+                { _tag = "Ast.TypeFunction",
+                    argtypes = { { _tag = "Ast.TypeName", name = "a" } },
+                    rettypes = { { _tag = "Ast.TypeName", name = "b" } } } )
         end)
 
 
         it("and -> is right associative", function()
             local ast1 = {
-                _tag = "AstTypeFunction",
+                _tag = "Ast.TypeFunction",
                 argtypes = {
-                    { _tag = "AstTypeName", name = "a" } },
+                    { _tag = "Ast.TypeName", name = "a" } },
                 rettypes = {
-                    { _tag = "AstTypeFunction",
-                        argtypes = { { _tag = "AstTypeName", name = "b" } },
-                        rettypes = { { _tag = "AstTypeName", name = "c" } } } } }
+                    { _tag = "Ast.TypeFunction",
+                        argtypes = { { _tag = "Ast.TypeName", name = "b" } },
+                        rettypes = { { _tag = "Ast.TypeName", name = "c" } } } } }
 
             local ast2 = {
-                _tag = "AstTypeFunction",
+                _tag = "Ast.TypeFunction",
                 argtypes = {
-                    { _tag = "AstTypeFunction",
-                        argtypes = { { _tag = "AstTypeName", name = "a" } },
-                        rettypes = { { _tag = "AstTypeName", name = "b" } } } },
+                    { _tag = "Ast.TypeFunction",
+                        argtypes = { { _tag = "Ast.TypeName", name = "a" } },
+                        rettypes = { { _tag = "Ast.TypeName", name = "b" } } } },
                 rettypes = {
-                    { _tag = "AstTypeName", name = "c" } } }
+                    { _tag = "Ast.TypeName", name = "c" } } }
 
             assert_type_ast("a -> b -> c",   ast1)
             assert_type_ast("a -> (b -> c)", ast1)
@@ -285,46 +285,46 @@ describe("Titan parser", function()
 
         it("and '->' has higher precedence than ','", function()
             assert_type_ast("(a, b -> c, d) -> e",
-                { _tag = "AstTypeFunction",
+                { _tag = "Ast.TypeFunction",
                     argtypes = {
-                        { _tag = "AstTypeName", name = "a" },
-                        { _tag = "AstTypeFunction",
-                          argtypes = { { _tag = "AstTypeName", name = "b" } },
-                          rettypes = { { _tag = "AstTypeName", name = "c" } } },
-                        { _tag = "AstTypeName", name = "d" } },
-                    rettypes = { { _tag = "AstTypeName", name = "e" } } } )
+                        { _tag = "Ast.TypeName", name = "a" },
+                        { _tag = "Ast.TypeFunction",
+                          argtypes = { { _tag = "Ast.TypeName", name = "b" } },
+                          rettypes = { { _tag = "Ast.TypeName", name = "c" } } },
+                        { _tag = "Ast.TypeName", name = "d" } },
+                    rettypes = { { _tag = "Ast.TypeName", name = "e" } } } )
         end)
     end)
 
     it("can parse values", function()
-        assert_expression_ast("nil",   { _tag = "AstExpNil" })
-        assert_expression_ast("false", { _tag = "AstExpBool", value = false })
-        assert_expression_ast("true",  { _tag = "AstExpBool", value = true })
-        assert_expression_ast("10",    { _tag = "AstExpInteger", value = 10})
-        assert_expression_ast("10.0",  { _tag = "AstExpFloat", value = 10.0})
-        assert_expression_ast("'asd'", { _tag = "AstExpString", value = "asd" })
+        assert_expression_ast("nil",   { _tag = "Ast.ExpNil" })
+        assert_expression_ast("false", { _tag = "Ast.ExpBool", value = false })
+        assert_expression_ast("true",  { _tag = "Ast.ExpBool", value = true })
+        assert_expression_ast("10",    { _tag = "Ast.ExpInteger", value = 10})
+        assert_expression_ast("10.0",  { _tag = "Ast.ExpFloat", value = 10.0})
+        assert_expression_ast("'asd'", { _tag = "Ast.ExpString", value = "asd" })
     end)
 
     it("can parse variables", function()
-        assert_expression_ast("y", { _tag = "AstExpVar", var = { _tag = "AstVarName", name = "y" }})
+        assert_expression_ast("y", { _tag = "Ast.ExpVar", var = { _tag = "Ast.VarName", name = "y" }})
     end)
 
     it("can parse parenthesized expressions", function()
-        assert_expression_ast("((1))", { _tag = "AstExpInteger", value = 1 })
+        assert_expression_ast("((1))", { _tag = "Ast.ExpInteger", value = 1 })
     end)
 
     it("can parse table constructors", function()
         assert_expression_ast("{}",
-            { _tag = "AstExpInitList", fields = {} })
+            { _tag = "Ast.ExpInitList", fields = {} })
 
         assert_expression_ast("{10,20,30}",
-            { _tag = "AstExpInitList", fields = {
+            { _tag = "Ast.ExpInitList", fields = {
                 { exp = { value = 10 } },
                 { exp = { value = 20 } },
                 { exp = { value = 30 } }, }})
 
         assert_expression_ast("{40;50;60;}", -- (semicolons)
-            { _tag = "AstExpInitList", fields = {
+            { _tag = "Ast.ExpInitList", fields = {
                 { exp = { value = 40 } },
                 { exp = { value = 50 } },
                 { exp = { value = 60 } }, }})
@@ -332,53 +332,53 @@ describe("Titan parser", function()
 
     describe("can parse while statements", function()
         assert_statements_ast("while true do end", {
-            { _tag = "AstStatWhile",
-              condition = { _tag = "AstExpBool" },
-              block = { _tag = "AstStatBlock" } }
+            { _tag = "Ast.StatWhile",
+              condition = { _tag = "Ast.ExpBool" },
+              block = { _tag = "Ast.StatBlock" } }
         })
     end)
 
     describe("can parse repeat-until statements", function()
         assert_statements_ast("repeat until false", {
-            { _tag = "AstStatRepeat",
-              block = { _tag = "AstStatBlock" },
-              condition = { _tag = "AstExpBool" }, }
+            { _tag = "Ast.StatRepeat",
+              block = { _tag = "Ast.StatBlock" },
+              condition = { _tag = "Ast.ExpBool" }, }
         })
     end)
 
     describe("can parse if statements", function()
         assert_statements_ast("if 10 then end", {
-            { _tag = "AstStatIf",
+            { _tag = "Ast.StatIf",
                 thens = {
-                    { _tag = "AstThen", condition = { value = 10 } },
+                    { _tag = "Ast.Then", condition = { value = 10 } },
                 },
               elsestat = false }
         })
 
         assert_statements_ast("if 20 then else end", {
-            { _tag = "AstStatIf",
+            { _tag = "Ast.StatIf",
                 thens = {
-                    { _tag = "AstThen", condition = { value = 20 } },
+                    { _tag = "Ast.Then", condition = { value = 20 } },
                 },
-                elsestat = { _tag = "AstStatBlock" } }
+                elsestat = { _tag = "Ast.StatBlock" } }
         })
 
         assert_statements_ast("if 30 then elseif 40 then end", {
-            { _tag = "AstStatIf",
+            { _tag = "Ast.StatIf",
                 thens = {
-                    { _tag = "AstThen", condition = { value = 30 } },
-                    { _tag = "AstThen", condition = { value = 40 } },
+                    { _tag = "Ast.Then", condition = { value = 30 } },
+                    { _tag = "Ast.Then", condition = { value = 40 } },
                 },
                 elsestat = false }
         })
 
         assert_statements_ast("if 50 then elseif 60 then else end", {
-            { _tag = "AstStatIf",
+            { _tag = "Ast.StatIf",
               thens = {
-                    { _tag = "AstThen", condition = { value = 50 } },
-                    { _tag = "AstThen", condition = { value = 60 } },
+                    { _tag = "Ast.Then", condition = { value = 50 } },
+                    { _tag = "Ast.Then", condition = { value = 60 } },
                 },
-                elsestat = { _tag = "AstStatBlock" } }
+                elsestat = { _tag = "Ast.StatBlock" } }
         })
     end)
 
@@ -389,16 +389,16 @@ describe("Titan parser", function()
                 print("Hello", "World")
             end
         ]], {
-            { _tag = "AstStatBlock",
+            { _tag = "Ast.StatBlock",
                 stats = {
-                    { _tag = "AstStatDecl",
+                    { _tag = "Ast.StatDecl",
                         decl = { name = "x" },
                         exp = { value = 10 } },
-                    { _tag = "AstStatAssign",
+                    { _tag = "Ast.StatAssign",
                         var = { name = "x" },
                         exp = { value = 11 } },
-                    { _tag = "AstStatCall",
-                        callexp = { _tag = "AstExpCall" } } } },
+                    { _tag = "Ast.StatCall",
+                        callexp = { _tag = "Ast.ExpCall" } } } },
         })
     end)
 
@@ -408,31 +408,31 @@ describe("Titan parser", function()
                 x = i
             end
         ]], {
-            { _tag = "AstStatFor",
+            { _tag = "Ast.StatFor",
               block = {
                 stats = {
-                  { _tag = "AstStatAssign",
-                    exp = { var = { _tag = "AstVarName", name = "i" } },
-                    var = { _tag = "AstVarName", name = "x" } } } },
-              decl = { _tag = "AstDecl", name = "i", type = false },
-              finish = { _tag = "AstExpInteger", value = 2 },
-              inc =    { _tag = "AstExpInteger", value = 3 },
-              start =  { _tag = "AstExpInteger", value = 1 } },
+                  { _tag = "Ast.StatAssign",
+                    exp = { var = { _tag = "Ast.VarName", name = "i" } },
+                    var = { _tag = "Ast.VarName", name = "x" } } } },
+              decl = { _tag = "Ast.Decl", name = "i", type = false },
+              finish = { _tag = "Ast.ExpInteger", value = 2 },
+              inc =    { _tag = "Ast.ExpInteger", value = 3 },
+              start =  { _tag = "Ast.ExpInteger", value = 1 } },
         })
     end)
 
     it("can parse return statements", function()
         assert_statements_ast("return", {
-            { _tag = "AstStatReturn", exp = false }})
+            { _tag = "Ast.StatReturn", exp = false }})
 
         assert_statements_ast("return;", {
-            { _tag = "AstStatReturn", exp = false }})
+            { _tag = "Ast.StatReturn", exp = false }})
 
         assert_statements_ast("return x", {
-            { _tag = "AstStatReturn", exp = { _tag = "AstExpVar" } },
+            { _tag = "Ast.StatReturn", exp = { _tag = "Ast.ExpVar" } },
         })
         assert_statements_ast("return x;", {
-            { _tag = "AstStatReturn", exp = { _tag = "AstExpVar" } },
+            { _tag = "Ast.StatReturn", exp = { _tag = "Ast.ExpVar" } },
         })
     end)
 
@@ -496,7 +496,7 @@ describe("Titan parser", function()
         -- concatenation is right associative
         -- and has less precedence than prefix operators
         assert_expression_ast([[-x .. -y .. -z]],
-            { _tag = "AstExpConcat", exps = {
+            { _tag = "Ast.ExpConcat", exps = {
                 { op = "-", exp = { var = { name = "x" } } },
                 { op = "-", exp = { var = { name = "y" } } },
                 { op = "-", exp = { var = { name = "z" } } },
@@ -518,67 +518,67 @@ describe("Titan parser", function()
 
     it("constant folds concatenation expressions", function()
         assert_expression_ast([["a" .. "b" .. "c"]],
-            { _tag = "AstExpString", value = "abc" })
+            { _tag = "Ast.ExpString", value = "abc" })
 
         assert_expression_ast([[1 .. 2]],
-            { _tag = "AstExpString", value = "12" })
+            { _tag = "Ast.ExpString", value = "12" })
 
         assert_expression_ast([[2.5 .. 1.5]],
-            { _tag = "AstExpString", value = "2.51.5" })
+            { _tag = "Ast.ExpString", value = "2.51.5" })
 
         assert_expression_ast([["a" .. 2]],
-            { _tag = "AstExpString", value = "a2" })
+            { _tag = "Ast.ExpString", value = "a2" })
 
         assert_expression_ast([[2 .. "a"]],
-            { _tag = "AstExpString", value = "2a" })
+            { _tag = "Ast.ExpString", value = "2a" })
     end)
 
     it("can parse suffix operators", function()
         assert_expression_ast([[ - x()()[2] ^ 3]],
-            { _tag = "AstExpUnop", op = "-",
-                exp = { _tag = "AstExpBinop", op = "^",
+            { _tag = "Ast.ExpUnop", op = "-",
+                exp = { _tag = "Ast.ExpBinop", op = "^",
                     rhs = { value = 3 },
-                    lhs = { _tag = "AstExpVar", var = {
-                        _tag = "AstVarBracket",
+                    lhs = { _tag = "Ast.ExpVar", var = {
+                        _tag = "Ast.VarBracket",
                         exp2 = { value = 2 },
-                        exp1 = { _tag = "AstExpCall",
-                            args = { _tag = "AstArgsFunc" },
-                            exp = { _tag = "AstExpCall",
-                                args = { _tag = "AstArgsFunc" },
-                                exp = { _tag = "AstExpVar",
-                                    var = { _tag = "AstVarName", name = "x" }}}}}}}})
+                        exp1 = { _tag = "Ast.ExpCall",
+                            args = { _tag = "Ast.ArgsFunc" },
+                            exp = { _tag = "Ast.ExpCall",
+                                args = { _tag = "Ast.ArgsFunc" },
+                                exp = { _tag = "Ast.ExpVar",
+                                    var = { _tag = "Ast.VarName", name = "x" }}}}}}}})
     end)
 
     it("can parse function calls without the optional parenthesis", function()
         assert_expression_ast([[ f() ]],
-            { _tag = "AstExpCall", args = {
-                _tag = "AstArgsFunc", args = { } } })
+            { _tag = "Ast.ExpCall", args = {
+                _tag = "Ast.ArgsFunc", args = { } } })
 
         assert_expression_ast([[ f "qwe" ]],
-            { _tag = "AstExpCall", args = {
-                _tag = "AstArgsFunc", args = {
-                    { _tag = "AstExpString", value = "qwe" } } } })
+            { _tag = "Ast.ExpCall", args = {
+                _tag = "Ast.ArgsFunc", args = {
+                    { _tag = "Ast.ExpString", value = "qwe" } } } })
 
         assert_expression_ast([[ f {} ]],
-            { _tag = "AstExpCall", args = {
-                _tag = "AstArgsFunc", args = {
-                    { _tag = "AstExpInitList" } } } })
+            { _tag = "Ast.ExpCall", args = {
+                _tag = "Ast.ArgsFunc", args = {
+                    { _tag = "Ast.ExpInitList" } } } })
     end)
 
     it("can parse method calls without the optional parenthesis", function()
         assert_expression_ast([[ o:m () ]],
-            { _tag = "AstExpCall", args = {
-                _tag = "AstArgsMethod", args = { } } })
+            { _tag = "Ast.ExpCall", args = {
+                _tag = "Ast.ArgsMethod", args = { } } })
 
         assert_expression_ast([[ o:m "asd" ]],
-            { _tag = "AstExpCall", args = {
-                _tag = "AstArgsMethod", args = {
-                    { _tag = "AstExpString", value = "asd" } } } })
+            { _tag = "Ast.ExpCall", args = {
+                _tag = "Ast.ArgsMethod", args = {
+                    { _tag = "Ast.ExpString", value = "asd" } } } })
 
         assert_expression_ast([[ o:m {} ]],
-            { _tag = "AstExpCall", args = {
-                _tag = "AstArgsMethod", args = {
-                    { _tag = "AstExpInitList" } } } })
+            { _tag = "Ast.ExpCall", args = {
+                _tag = "Ast.ArgsMethod", args = {
+                    { _tag = "Ast.ExpInitList" } } } })
     end)
 
     it("only allows call expressions as statements", function()
@@ -595,7 +595,7 @@ describe("Titan parser", function()
 
     it("can parse import", function ()
         assert_program_ast([[ local foo = import "module.foo" ]], {
-            { _tag = "AstTopLevelImport", localname = "foo", modname = "module.foo" },
+            { _tag = "Ast.TopLevelImport", localname = "foo", modname = "module.foo" },
         })
     end)
 
@@ -606,22 +606,22 @@ describe("Titan parser", function()
             foo.write(a, b, c)
         ]], {
             { var = {
-                _tag = "AstVarDot",
-                exp = { _tag = "AstExpVar",
-                  var = { _tag = "AstVarName", name = "foo" }
+                _tag = "Ast.VarDot",
+                exp = { _tag = "Ast.ExpVar",
+                  var = { _tag = "Ast.VarName", name = "foo" }
                 },
                 name = "bar" } },
             { callexp = { args = { args = { { var = {
-                _tag = "AstVarDot",
-                exp = { _tag = "AstExpVar",
-                  var = { _tag = "AstVarName", name = "foo" }
+                _tag = "Ast.VarDot",
+                exp = { _tag = "Ast.ExpVar",
+                  var = { _tag = "Ast.VarName", name = "foo" }
                 },
               name = "bar" } } } } } },
             { callexp = {
                 exp = { var = {
-                    _tag = "AstVarDot",
-                    exp = { _tag = "AstExpVar",
-                      var = { _tag = "AstVarName", name = "foo" }
+                    _tag = "Ast.VarDot",
+                    exp = { _tag = "Ast.ExpVar",
+                      var = { _tag = "Ast.VarName", name = "foo" }
                     },
                     name = "write" } } } }
         })
@@ -634,11 +634,11 @@ describe("Titan parser", function()
                 y: float
             end
         ]], {
-            { _tag = "AstTopLevelRecord",
+            { _tag = "Ast.TopLevelRecord",
               name = "Point",
               fields = {
-                { name = "x", type = { _tag = "AstTypeFloat" } },
-                { name = "y", type = { _tag = "AstTypeFloat" } } } },
+                { name = "x", type = { _tag = "Ast.TypeFloat" } },
+                { name = "y", type = { _tag = "Ast.TypeFloat" } } } },
         })
 
         assert_program_ast([[
@@ -647,7 +647,7 @@ describe("Titan parser", function()
                 next: List
             end
         ]], {
-            { _tag = "AstTopLevelRecord",
+            { _tag = "Ast.TopLevelRecord",
               name = "List",
               fields = {
                 { name = "p",
@@ -678,63 +678,63 @@ describe("Titan parser", function()
 
     it("can parse record constructors", function()
         assert_expression_ast([[ { x = 1.1, y = 2.2 } ]],
-            { _tag = "AstExpInitList", fields = {
+            { _tag = "Ast.ExpInitList", fields = {
                 { name = "x", exp = { value = 1.1 } },
                 { name = "y", exp = { value = 2.2 } } }})
 
         assert_expression_ast([[ { p = {}, next = nil } ]],
-            { _tag = "AstExpInitList", fields = {
-                { name = "p",    exp = { _tag = "AstExpInitList" } },
-                { name = "next", exp = { _tag = "AstExpNil" } } }})
+            { _tag = "Ast.ExpInitList", fields = {
+                { name = "p",    exp = { _tag = "Ast.ExpInitList" } },
+                { name = "next", exp = { _tag = "Ast.ExpNil" } } }})
 
         assert_expression_ast([[ Point.new(1.1, 2.2) ]],
-            { _tag = "AstExpCall",
+            { _tag = "Ast.ExpCall",
                 args = { args = {
                   { value = 1.1 },
                   { value = 2.2 } } },
                 exp = { var = {
-                    _tag = "AstVarDot",
+                    _tag = "Ast.VarDot",
                     exp = { var = { name = "Point" } },
                     name = "new" } } })
 
         assert_expression_ast([[ List.new({}, nil) ]],
-            { _tag = "AstExpCall",
+            { _tag = "Ast.ExpCall",
                 args = { args = {
-                  { _tag = "AstExpInitList" },
-                  { _tag = "AstExpNil" } } },
+                  { _tag = "Ast.ExpInitList" },
+                  { _tag = "Ast.ExpNil" } } },
                 exp = { var = {
-                    _tag = "AstVarDot",
+                    _tag = "Ast.VarDot",
                     exp = { var = { name = "List" } },
                     name = "new" } } })
     end)
 
     it("can parse record field access", function()
         assert_expression_ast([[ p.x ]],
-            { _tag = "AstExpVar", var = { _tag = "AstVarDot",
+            { _tag = "Ast.ExpVar", var = { _tag = "Ast.VarDot",
                 name = "x",
-                exp = { _tag = "AstExpVar", var = { _tag = "AstVarName",
+                exp = { _tag = "Ast.ExpVar", var = { _tag = "Ast.VarName",
                     name = "p" } } } })
 
         assert_expression_ast([[ a.b[1].c ]],
-            { _tag = "AstExpVar", var = { _tag = "AstVarDot",
+            { _tag = "Ast.ExpVar", var = { _tag = "Ast.VarDot",
                 name = "c",
-                exp = { _tag = "AstExpVar", var = { _tag = "AstVarBracket",
+                exp = { _tag = "Ast.ExpVar", var = { _tag = "Ast.VarBracket",
                     exp2 = { value = 1 },
-                    exp1 = { _tag = "AstExpVar", var = { _tag = "AstVarDot",
+                    exp1 = { _tag = "Ast.ExpVar", var = { _tag = "Ast.VarDot",
                         name = "b",
-                        exp = { _tag = "AstExpVar", var = { _tag = "AstVarName",
+                        exp = { _tag = "Ast.ExpVar", var = { _tag = "Ast.VarName",
                             name = "a" } } } } } } } })
     end)
 
     it("can parse cast expressions", function()
         assert_expression_ast([[ foo as integer ]],
-            { _tag = "AstExpCast", exp = { _tag = "AstExpVar" }, target = { _tag = "AstTypeInteger" } })
+            { _tag = "Ast.ExpCast", exp = { _tag = "Ast.ExpVar" }, target = { _tag = "Ast.TypeInteger" } })
         assert_expression_ast([[ a.b[1].c as integer ]],
-            { _tag = "AstExpCast", exp = { _tag = "AstExpVar" }, target = { _tag = "AstTypeInteger" } })
+            { _tag = "Ast.ExpCast", exp = { _tag = "Ast.ExpVar" }, target = { _tag = "Ast.TypeInteger" } })
         assert_expression_ast([[ foo as { integer } ]],
-            { _tag = "AstExpCast", exp = { _tag = "AstExpVar" }, target = { _tag = "AstTypeArray" } })
+            { _tag = "Ast.ExpCast", exp = { _tag = "Ast.ExpVar" }, target = { _tag = "Ast.TypeArray" } })
         assert_expression_ast([[ 2 + foo as integer ]],
-            { rhs = { _tag = "AstExpCast", exp = { _tag = "AstExpVar" }, target = { _tag = "AstTypeInteger" } }})
+            { rhs = { _tag = "Ast.ExpCast", exp = { _tag = "Ast.ExpVar" }, target = { _tag = "Ast.TypeInteger" } }})
     end)
 
     it("does not allow parentheses in the LHS of an assignment", function()

--- a/titan-compiler/checker.lua
+++ b/titan-compiler/checker.lua
@@ -279,7 +279,7 @@ checkstat = util.make_visitor({
     end,
 
     ["Ast.StatReturn"] = function(node, st, errors)
-        local ftype = st:find_symbol(".function")._type
+        local ftype = st:find_symbol("$function")._type
         assert(#ftype.rettypes == 1)
         local tret = ftype.rettypes[1]
         checkexp(node.exp, st, errors, tret)
@@ -736,7 +736,7 @@ checkexp = util.make_visitor({
 local function checkfunc(node, st, errors)
     local l, _ = util.get_line_number(errors.subject, node._pos)
     node._lin = l
-    st:add_symbol(".function", node) -- for return type
+    st:add_symbol("$function", node) -- for return type
     local ptypes = node._type.params
     local pnames = {}
     for i, param in ipairs(node.params) do

--- a/titan-compiler/coder.lua
+++ b/titan-compiler/coder.lua
@@ -46,9 +46,9 @@ end
 -- Note to self: A constant-folding optimization pass would obsolete this
 local function node2literal(node)
     local tag = node._tag
-    if tag == "AstExpInteger" or tag == "AstExpFloat" then
+    if tag == "Ast.ExpInteger" or tag == "Ast.ExpFloat" then
         return tonumber(node.value)
-    elseif tag == "AstExpUnop" and node.op == "-" then
+    elseif tag == "Ast.ExpUnop" and node.op == "-" then
         local lexp = node2literal(node.exp)
         return lexp and -lexp
     else
@@ -59,21 +59,21 @@ end
 local function getslot(typ --[[:table]], dst --[[:string?]], src --[[:string]])
     dst = dst and dst .. " =" or ""
     local tmpl
-    if typ._tag == "TypeInteger" then tmpl = "$DST ivalue($SRC)"
-    elseif typ._tag == "TypeFloat" then tmpl = "$DST fltvalue($SRC)"
-    elseif typ._tag == "TypeBoolean" then tmpl = "$DST bvalue($SRC)"
-    elseif typ._tag == "TypeNil" then tmpl = "$DST 0"
-    elseif typ._tag == "TypeString" then tmpl = "$DST tsvalue($SRC)"
-    elseif typ._tag == "TypeArray" then tmpl = "$DST hvalue($SRC)"
-    elseif typ._tag == "TypeValue" then tmpl = "$DST *($SRC)"
-    elseif typ._tag == "TypeRecord" then tmpl = "" -- TODO records
+    if typ._tag == "Type.Integer" then tmpl = "$DST ivalue($SRC)"
+    elseif typ._tag == "Type.Float" then tmpl = "$DST fltvalue($SRC)"
+    elseif typ._tag == "Type.Boolean" then tmpl = "$DST bvalue($SRC)"
+    elseif typ._tag == "Type.Nil" then tmpl = "$DST 0"
+    elseif typ._tag == "Type.String" then tmpl = "$DST tsvalue($SRC)"
+    elseif typ._tag == "Type.Array" then tmpl = "$DST hvalue($SRC)"
+    elseif typ._tag == "Type.Value" then tmpl = "$DST *($SRC)"
+    elseif typ._tag == "Type.Record" then tmpl = "" -- TODO records
     else error("invalid type " .. types.tostring(typ)) end
     return render(tmpl, { DST = dst, SRC = src })
 end
 
 local function checkandget(typ --[[:table]], cvar --[[:string]], exp --[[:string]], line --[[:number]])
     local tag
-    if typ._tag == "TypeInteger" then
+    if typ._tag == "Type.Integer" then
         return render([[
             if (TITAN_LIKELY(ttisinteger($EXP))) {
                 $VAR = ivalue($EXP);
@@ -93,7 +93,7 @@ local function checkandget(typ --[[:table]], cvar --[[:string]], exp --[[:string
             VAR = cvar,
             LINE = c_integer_literal(line)
         })
-    elseif typ._tag == "TypeFloat" then
+    elseif typ._tag == "Type.Float" then
         return render([[
             if (TITAN_LIKELY(ttisfloat($EXP))) {
                 $VAR = fltvalue($EXP);
@@ -107,7 +107,7 @@ local function checkandget(typ --[[:table]], cvar --[[:string]], exp --[[:string
             VAR = cvar,
             LINE = c_integer_literal(line),
         })
-    elseif typ._tag == "TypeBoolean" then
+    elseif typ._tag == "Type.Boolean" then
         return render([[
             if (l_isfalse($EXP)) {
                 $VAR = 0;
@@ -118,17 +118,17 @@ local function checkandget(typ --[[:table]], cvar --[[:string]], exp --[[:string
             EXP = exp,
             VAR = cvar
         })
-    elseif typ._tag == "TypeNil" then tag = "nil"
-    elseif typ._tag == "TypeString" then tag = "string"
-    elseif typ._tag == "TypeArray" then tag = "table"
-    elseif typ._tag == "TypeValue" then
+    elseif typ._tag == "Type.Nil" then tag = "nil"
+    elseif typ._tag == "Type.String" then tag = "string"
+    elseif typ._tag == "Type.Array" then tag = "table"
+    elseif typ._tag == "Type.Value" then
         return render([[
             setobj2t(L, &$VAR, $EXP);
         ]], {
             EXP = exp,
             VAR = cvar
         })
-    elseif typ._tag == "TypeRecord" then
+    elseif typ._tag == "Type.Record" then
         -- TODO records
         tag = "table"
     else
@@ -151,8 +151,8 @@ end
 
 local function checkandset(typ --[[:table]], dst --[[:string]], src --[[:string]], line --[[:number]])
     local tag
-    if typ._tag == "TypeInteger" then tag = "integer"
-    elseif typ._tag == "TypeFloat" then
+    if typ._tag == "Type.Integer" then tag = "integer"
+    elseif typ._tag == "Type.Float" then
         return render([[
             if (TITAN_LIKELY(ttisfloat($SRC))) {
                 setobj2t(L, $DST, $SRC);
@@ -166,11 +166,11 @@ local function checkandset(typ --[[:table]], dst --[[:string]], src --[[:string]
             DST = dst,
             LINE = c_integer_literal(line),
         })
-    elseif typ._tag == "TypeBoolean" then tag = "boolean"
-    elseif typ._tag == "TypeNil" then tag = "nil"
-    elseif typ._tag == "TypeString" then tag = "string"
-    elseif typ._tag == "TypeArray" then tag = "table"
-    elseif typ._tag == "TypeValue" then
+    elseif typ._tag == "Type.Boolean" then tag = "boolean"
+    elseif typ._tag == "Type.Nil" then tag = "nil"
+    elseif typ._tag == "Type.String" then tag = "string"
+    elseif typ._tag == "Type.Array" then tag = "table"
+    elseif typ._tag == "Type.Value" then
         return render([[
             setobj2t(L, $DST, $SRC);
         ]], {
@@ -197,13 +197,13 @@ end
 
 local function setslot(typ --[[:table]], dst --[[:string]], src --[[:string]])
     local tmpl
-    if typ._tag == "TypeInteger" then tmpl = "setivalue($DST, $SRC);"
-    elseif typ._tag == "TypeFloat" then tmpl = "setfltvalue($DST, $SRC);"
-    elseif typ._tag == "TypeBoolean" then tmpl = "setbvalue($DST, $SRC);"
-    elseif typ._tag == "TypeNil" then tmpl = "setnilvalue($DST); ((void)$SRC);"
-    elseif typ._tag == "TypeString" then tmpl = "setsvalue(L, $DST, $SRC);"
-    elseif typ._tag == "TypeArray" then tmpl = "sethvalue(L, $DST, $SRC);"
-    elseif typ._tag == "TypeValue" then tmpl = "setobj2t(L, $DST, &$SRC);"
+    if typ._tag == "Type.Integer" then tmpl = "setivalue($DST, $SRC);"
+    elseif typ._tag == "Type.Float" then tmpl = "setfltvalue($DST, $SRC);"
+    elseif typ._tag == "Type.Boolean" then tmpl = "setbvalue($DST, $SRC);"
+    elseif typ._tag == "Type.Nil" then tmpl = "setnilvalue($DST); ((void)$SRC);"
+    elseif typ._tag == "Type.String" then tmpl = "setsvalue(L, $DST, $SRC);"
+    elseif typ._tag == "Type.Array" then tmpl = "sethvalue(L, $DST, $SRC);"
+    elseif typ._tag == "Type.Value" then tmpl = "setobj2t(L, $DST, &$SRC);"
     else
         error("invalid type " .. types.tostring(typ))
     end
@@ -211,20 +211,20 @@ local function setslot(typ --[[:table]], dst --[[:string]], src --[[:string]])
 end
 
 local function ctype(typ --[[:table]])
-    if typ._tag == "TypeInteger" then return "lua_Integer"
-    elseif typ._tag == "TypeFloat" then return "lua_Number"
-    elseif typ._tag == "TypeBoolean" then return "int"
-    elseif typ._tag == "TypeNil" then return "int"
-    elseif typ._tag == "TypeString" then return "TString*"
-    elseif typ._tag == "TypeArray" then return "Table*"
-    elseif typ._tag == "TypeValue" then return "TValue"
-    elseif typ._tag == "TypeRecord" then return "TValue"
+    if typ._tag == "Type.Integer" then return "lua_Integer"
+    elseif typ._tag == "Type.Float" then return "lua_Number"
+    elseif typ._tag == "Type.Boolean" then return "int"
+    elseif typ._tag == "Type.Nil" then return "int"
+    elseif typ._tag == "Type.String" then return "TString*"
+    elseif typ._tag == "Type.Array" then return "Table*"
+    elseif typ._tag == "Type.Value" then return "TValue"
+    elseif typ._tag == "Type.Record" then return "TValue"
     else error("invalid type " .. types.tostring(typ))
     end
 end
 
 local function initval(typ --[[:table]])
-    if typ._tag == "TypeValue" then return "{ {0}, 0 }"
+    if typ._tag == "Type.Value" then return "{ {0}, 0 }"
     else return "0" end
 end
 
@@ -413,7 +413,7 @@ local function codefor(ctx, node)
     local cfstats, cfexp = codeexp(ctx, node.finish)
     local cinc = ""
     local cvtyp
-    if node.decl._type._tag == "TypeInteger" then
+    if node.decl._type._tag == "Type.Integer" then
         cvtyp = "lua_Integer"
     else
         cvtyp = "lua_Number"
@@ -443,7 +443,7 @@ local function codefor(ctx, node)
         if ilit then
             if ilit > 0 then
                 local tmpl
-                if node.decl._type._tag == "TypeInteger" then
+                if node.decl._type._tag == "Type.Integer" then
                     subs.ILIT = c_integer_literal(ilit)
                     tmpl = "$CVAR = l_castU2S(l_castS2U($CVAR) + $ILIT)"
                 else
@@ -453,7 +453,7 @@ local function codefor(ctx, node)
                 cstep = render(tmpl, subs)
                 ccmp = render("$CVAR <= _forlimit", subs)
             else
-                if node.decl._type._tag == "TypeInteger" then
+                if node.decl._type._tag == "Type.Integer" then
                     subs.NEGILIT = c_integer_literal(-ilit)
                     cstep = render("$CVAR = l_castU2S(l_castS2U($CVAR) - $NEGILIT)", subs)
                 else
@@ -473,7 +473,7 @@ local function codefor(ctx, node)
                 CVTYP = cvtyp,
             })
             local tmpl
-            if node.decl._type._tag == "TypeInteger" then
+            if node.decl._type._tag == "Type.Integer" then
                 tmpl = "$CVAR = l_castU2S(l_castS2U($CVAR) + l_castS2U(_forstep))"
             else
                 tmpl = "$CVAR += _forstep"
@@ -482,7 +482,7 @@ local function codefor(ctx, node)
             ccmp = render("0 < _forstep ? ($CVAR <= _forlimit) : (_forlimit <= $CVAR)", subs)
         end
     else
-        if node.decl._type._tag == "TypeInteger" then
+        if node.decl._type._tag == "Type.Integer" then
             cstep = render("$CVAR = l_castU2S(l_castS2U($CVAR) + 1)", subs)
         else
             cstep = render("$CVAR += 1.0", subs)
@@ -519,8 +519,8 @@ local function codeassignment(ctx, node)
     -- has to generate different code if lvar is just a variable
     -- or an array indexing.
     local vtag = node.var._tag
-    if vtag == "AstVarName" or (vtag == "AstVarDot" and node.var._decl) then
-        if vtag == "AstVarDot" or (node.var._decl._tag == "AstTopLevelVar" and not node.var._decl.islocal) then
+    if vtag == "Ast.VarName" or (vtag == "Ast.VarDot" and node.var._decl) then
+        if vtag == "Ast.VarDot" or (node.var._decl._tag == "Ast.TopLevelVar" and not node.var._decl.islocal) then
             local cstats, cexp = codeexp(ctx, node.exp)
             return render([[
                 $CSTATS
@@ -553,7 +553,7 @@ local function codeassignment(ctx, node)
                 CSET = cset,
             })
         end
-    elseif vtag == "AstVarBracket" then
+    elseif vtag == "Ast.VarBracket" then
         local arr = node.var.exp1
         local idx = node.var.exp2
         local etype = node.exp._type
@@ -617,9 +617,9 @@ local function codecall(ctx, node)
     local castats, caexps = {}, { "L" }
     local fname
     local fnode = node.exp.var
-    if fnode._tag == "AstVarName" then
+    if fnode._tag == "Ast.VarName" then
         fname = ctx.prefix .. fnode.name .. '_titan'
-    elseif node.exp.var._tag == "AstVarDot" then
+    elseif node.exp.var._tag == "Ast.VarDot" then
         fname = fnode.exp._type.prefix .. fnode.name .. "_titan"
     end
     for _, arg in ipairs(node.args.args) do
@@ -689,7 +689,7 @@ end
 
 function codestat(ctx, node)
     local tag = node._tag
-    if tag == "AstStatDecl" then
+    if tag == "Ast.StatDecl" then
         local cstats, cexp = codeexp(ctx, node.exp)
         if node.decl._used then
             local typ = node.decl._type
@@ -732,22 +732,22 @@ function codestat(ctx, node)
                 CEXP = cexp
             })
         end
-    elseif tag == "AstStatBlock" then
+    elseif tag == "Ast.StatBlock" then
         return codeblock(ctx, node)
-    elseif tag == "AstStatWhile" then
+    elseif tag == "Ast.StatWhile" then
         return codewhile(ctx, node)
-    elseif tag == "AstStatRepeat" then
+    elseif tag == "Ast.StatRepeat" then
         return coderepeat(ctx, node)
-    elseif tag == "AstStatIf" then
+    elseif tag == "Ast.StatIf" then
         return codeif(ctx, node)
-    elseif tag == "AstStatFor" then
+    elseif tag == "Ast.StatFor" then
         return codefor(ctx, node)
-    elseif tag == "AstStatAssign" then
+    elseif tag == "Ast.StatAssign" then
         return codeassignment(ctx, node)
-    elseif tag == "AstStatCall" then
+    elseif tag == "Ast.StatCall" then
       local cstats, cexp = codecall(ctx, node.callexp)
       return cstats .. "\n    " .. cexp .. ";"
-    elseif tag == "AstStatReturn" then
+    elseif tag == "Ast.StatReturn" then
         return codereturn(ctx, node)
     else
         error("invalid node tag " .. tag)
@@ -761,7 +761,7 @@ end
 -- the preliminary code is always the empty string
 
 local function codevar(ctx, node)
-    if node._tag == "AstVarDot" or (node._decl._tag == "AstTopLevelVar" and not node._decl.islocal) then
+    if node._tag == "Ast.VarDot" or (node._decl._tag == "Ast.TopLevelVar" and not node._decl.islocal) then
         return "", getslot(node._type, nil, node._decl._slot)
     else
         return "", node._decl._cvar
@@ -770,15 +770,15 @@ end
 
 local function codevalue(ctx, node, target)
     local tag = node._tag
-    if tag == "AstExpNil" then
+    if tag == "Ast.ExpNil" then
         return "", "0"
-    elseif tag == "AstExpBool" then
+    elseif tag == "Ast.ExpBool" then
         return "", node.value and "1" or "0"
-    elseif tag == "AstExpInteger" then
+    elseif tag == "Ast.ExpInteger" then
         return "", c_integer_literal(node.value)
-    elseif tag == "AstExpFloat" then
+    elseif tag == "Ast.ExpFloat" then
         return "", c_float_literal(node.value)
-    elseif tag == "AstExpString" then
+    elseif tag == "Ast.ExpString" then
         local cstr = render("luaS_new(L, $VALUE)", {
             VALUE = c_string_literal(node.value)
         })
@@ -887,7 +887,7 @@ local function codeunaryop(ctx, node, iscondition)
         return estats, "!(" .. ecode .. ")"
     elseif op == "#" then
         local estats, ecode = codeexp(ctx, node.exp)
-        if node.exp._type._tag == "TypeArray" then
+        if node.exp._type._tag == "Type.Array" then
             return estats, "luaH_getn(" .. ecode .. ")"
         else
             return estats, "tsslen(" .. ecode .. ")"
@@ -1038,33 +1038,33 @@ end
 --    in this case it will be the '_decl' of the lvalue
 function codeexp(ctx, node, iscondition, target)
     local tag = node._tag
-    if tag == "AstVarName" or (tag == "AstVarDot" and node._decl) then
+    if tag == "Ast.VarName" or (tag == "Ast.VarDot" and node._decl) then
         return codevar(ctx, node)
-    elseif tag == "AstVarBracket" then
+    elseif tag == "Ast.VarBracket" then
         return codeindex(ctx, node, iscondition)
-    elseif tag == "AstExpNil" or
-                tag == "AstExpBool" or
-                tag == "AstExpInteger" or
-                tag == "AstExpFloat" or
-                tag == "AstExpString" then
+    elseif tag == "Ast.ExpNil" or
+                tag == "Ast.ExpBool" or
+                tag == "Ast.ExpInteger" or
+                tag == "Ast.ExpFloat" or
+                tag == "Ast.ExpString" then
             return codevalue(ctx, node, target)
-    elseif tag == "AstExpInitList" then
+    elseif tag == "Ast.ExpInitList" then
             return codetable(ctx, node, target)
-    elseif tag == "AstExpVar" then
+    elseif tag == "Ast.ExpVar" then
         return codeexp(ctx, node.var, iscondition)
-    elseif tag == "AstExpUnop" then
+    elseif tag == "Ast.ExpUnop" then
             return codeunaryop(ctx, node, iscondition)
-    elseif tag == "AstExpBinop" then
+    elseif tag == "Ast.ExpBinop" then
             return codebinaryop(ctx, node, iscondition)
-    elseif tag == "AstExpCall" then
+    elseif tag == "Ast.ExpCall" then
         return codecall(ctx, node, target)
-    elseif tag == "AstExpCast" and node.exp._tag == "AstExpVar" and node.exp.var._tag == "AstVarBracket" then
+    elseif tag == "Ast.ExpCast" and node.exp._tag == "Ast.ExpVar" and node.exp.var._tag == "Ast.VarBracket" then
         local t = node.exp.var._type
         node.exp.var._type = node.target
         local cstats, cexp = codeexp(ctx, node.exp.var, iscondition)
         node.exp.var._type = t
         return cstats, cexp
-    elseif tag == "AstExpCast" and node.exp._type._tag == "TypeValue" then
+    elseif tag == "Ast.ExpCast" and node.exp._type._tag == "Type.Value" then
         local cstats, cexp = codeexp(ctx, node.exp, iscondition)
         local ctmps, tmpnames = newtmp(ctx, node.exp._type)
         local ctmpt, tmpnamet = newtmp(ctx, node.target)
@@ -1083,7 +1083,7 @@ function codeexp(ctx, node, iscondition, target)
             EXP = cexp,
             CHECKANDGET = cget
         }), tmpnamet
-    elseif tag == "AstExpCast" and node.target._tag == "TypeValue" then
+    elseif tag == "Ast.ExpCast" and node.target._tag == "Type.Value" then
         local cstats, cexp = codeexp(ctx, node.exp, iscondition)
         local ctmp, tmpname = newtmp(ctx, node.target)
         return render([[
@@ -1095,13 +1095,13 @@ function codeexp(ctx, node, iscondition, target)
             TMPTARGET = ctmp,
             SETSLOT = setslot(node.exp._type, "&" .. tmpname, cexp)
         }), tmpname
-    elseif tag == "AstExpCast" and node.target._tag == "TypeFloat" then
+    elseif tag == "Ast.ExpCast" and node.target._tag == "Type.Float" then
         local cstat, cexp = codeexp(ctx, node.exp)
         return cstat, "((lua_Number)" .. cexp .. ")"
-    elseif tag == "AstExpCast" and node.target._tag == "TypeBoolean" then
+    elseif tag == "Ast.ExpCast" and node.target._tag == "Type.Boolean" then
         local cstat, cexp = codeexp(ctx, node.exp, true)
         return cstat, "((" .. cexp .. ") ? 1 : 0)"
-    elseif tag == "AstExpCast" and node.target._tag == "TypeInteger" then
+    elseif tag == "Ast.ExpCast" and node.target._tag == "Type.Integer" then
         local cstat, cexp = codeexp(ctx, node.exp)
         local ctmp1, tmpname1 = newtmp(ctx, types.Float())
         local ctmp2, tmpname2 = newtmp(ctx, types.Float())
@@ -1130,12 +1130,12 @@ function codeexp(ctx, node, iscondition, target)
             LINE = c_integer_literal(node._lin)
         })
         return cfloor, tmpname3
-    elseif tag == "AstExpCast" and node.target._tag == "TypeString" then
+    elseif tag == "Ast.ExpCast" and node.target._tag == "Type.String" then
         local cvt
         local cstats, cexp = codeexp(ctx, node.exp)
-        if node.exp._type._tag == "TypeInteger" then
+        if node.exp._type._tag == "Type.Integer" then
             cvt = render("_integer2str(L, $EXP)", { EXP = cexp })
-        elseif node.exp._type._tag == "TypeFloat" then
+        elseif node.exp._type._tag == "Type.Float" then
             cvt = render("_float2str(L, $EXP)", { EXP = cexp })
         else
             error("invalid node type for coercion to string " .. types.tostring(node.exp._type))
@@ -1156,7 +1156,7 @@ function codeexp(ctx, node, iscondition, target)
             })
             return code, tmpname
         end
-    elseif tag == "AstExpConcat" then
+    elseif tag == "Ast.ExpConcat" then
         local strs, copies = {}, {}
         local ctmp, tmpname, tmpslot = newtmp(ctx, types.String(), true)
         for i, exp in ipairs(node.exps) do
@@ -1263,7 +1263,7 @@ local function codefuncdec(tlcontext, node)
         TValue *_retslot = _base;]])
     end
     table.insert(stats, body)
-    if rettype._tag == "TypeNil" then
+    if rettype._tag == "Type.Nil" then
         if nslots > 0 then
             table.insert(stats, [[
             L->top = _base;
@@ -1594,7 +1594,7 @@ function coder.generate(modname, ast)
     for _, node in pairs(ast) do
         if not node._ignore then
             local tag = node._tag
-            if tag == "AstTopLevelImport" then
+            if tag == "Ast.TopLevelImport" then
                 local mprefix = node._type.prefix
                 table.insert(initmods, render([[
                     void *$HANDLE = loadlib(L, "$FILE");
@@ -1603,10 +1603,10 @@ function coder.generate(modname, ast)
                 ]], { HANDLE = mprefix .. "handle", INIT = mprefix .. "init", FILE = node._type.file}));
                 table.insert(deps, node.modname)
                 for name, member in pairs(node._type.members) do
-                    if not member._slot and member._tag ~= "TypeFunction" then
+                    if not member._slot and member._tag ~= "Type.Function" then
                         member._slot = mprefix .. name .. "_titanvar"
                     end
-                    if member._tag == "TypeFunction" then
+                if member._tag == "Type.Function" then
                         local fname = mprefix .. name .. "_titan"
                         table.insert(includes, externalsig(fname, member))
                         table.insert(initmods, render([[
@@ -1633,7 +1633,7 @@ function coder.generate(modname, ast)
     for _, node in pairs(ast) do
         if not node._ignore then
             local tag = node._tag
-            if tag == "AstTopLevelVar" then
+            if tag == "Ast.TopLevelVar" then
                 codevardec(tlcontext, initctx, node)
                 table.insert(code, node._cdecl)
                 table.insert(initvars, node._init)
@@ -1650,7 +1650,7 @@ function coder.generate(modname, ast)
     for _, node in pairs(ast) do
         if not node._ignore then
             local tag = node._tag
-            if tag == "AstTopLevelFunc" then
+            if tag == "Ast.TopLevelFunc" then
                 codefuncdec(tlcontext, node)
                 table.insert(code, node._body)
                 if not node.islocal then

--- a/titan-compiler/parser.lua
+++ b/titan-compiler/parser.lua
@@ -89,15 +89,15 @@ end
 -- Should this go on a separate constant propagation pass?
 function defs.binop_concat(pos, lhs, op, rhs)
     if op then
-        if rhs._tag == "AstExpConcat" then
+        if rhs._tag == "Ast.ExpConcat" then
             table.insert(rhs.exps, 1, lhs)
             return rhs
-        elseif (lhs._tag == "AstExpString" or
-            lhs._tag == "AstExpInteger" or
-            lhs._tag == "AstExpFloat") and
-            (rhs._tag == "AstExpString" or
-            rhs._tag == "AstExpInteger" or
-            rhs._tag == "AstExpFloat") then
+        elseif (lhs._tag == "Ast.ExpString" or
+            lhs._tag == "Ast.ExpInteger" or
+            lhs._tag == "Ast.ExpFloat") and
+            (rhs._tag == "Ast.ExpString" or
+            rhs._tag == "Ast.ExpInteger" or
+            rhs._tag == "Ast.ExpFloat") then
             return ast.ExpString(pos, lhs.value .. rhs.value)
         else
             return ast.ExpConcat(pos, { lhs, rhs })
@@ -163,7 +163,7 @@ function defs.exp2var(exp)
 end
 
 function defs.exp_is_var(_, pos, exp)
-    if exp._tag == "AstExpVar" then
+    if exp._tag == "Ast.ExpVar" then
         return pos, exp
     else
         return false
@@ -171,7 +171,7 @@ function defs.exp_is_var(_, pos, exp)
 end
 
 function defs.exp_is_call(_, pos, exp)
-    if exp._tag == "AstExpCall" then
+    if exp._tag == "Ast.ExpCall" then
         return pos, exp
     else
         return false

--- a/titan-compiler/typedecl.lua
+++ b/titan-compiler/typedecl.lua
@@ -12,12 +12,13 @@ return function(oblfields, prefix, types)
     local constructors = {}
     for typename, conss in pairs(types) do
         for consname, fields in pairs(conss) do
+            local tag = prefix .. "." .. consname
             constructors[consname] = function(...)
                 local args = table.pack(...)
                 if args.n ~= #oblfields + #fields then
                     error("missing arguments for " .. consname)
                 end
-                local node = { _tag = prefix .. consname }
+                local node = { _tag = tag }
                 fill(node, args, oblfields, 0)
                 fill(node, args, fields, #oblfields)
                 return node


### PR DESCRIPTION
This should protect against accidental collisions.
Without a separator, Foo.BarBaz and FooBar.Baz would end up with the
same tag (FooBarBaz).