### PR TITLE
Fix some Luacheck warnings

### DIFF
--- a/.luacheckrc
+++ b/.luacheckrc
@@ -14,5 +14,8 @@
 
 ignore = {
     "212/_.*", -- Unused argument, (unless name starts with "_")
-    "542", -- An empty if branch.
+    "411/err", -- Redefining local (unless called "err")
+    "421/err", -- Shadowing local (unless called "err")
+    "542", -- Empty if branch.
+    "6..", -- Whitespace warnings
 }

--- a/titan-compiler/checker.lua
+++ b/titan-compiler/checker.lua
@@ -32,10 +32,10 @@ local check_exp
 -- @ param prog AST for the whole module
 -- @ return true or false, followed by as list of compilation errors
 function checker.check(filename, input)
-    local ast, errors = scope_analysis.bind_names(filename, input)
-    if not ast then return false, errors end
-    check_program(ast, errors)
-    return (#errors == 0 and ast), errors
+    local prog, errors = scope_analysis.bind_names(filename, input)
+    if not prog then return false, errors end
+    check_program(prog, errors)
+    return (#errors == 0 and prog), errors
 end
 
 --
@@ -495,11 +495,11 @@ check_exp = function(exp, errors, typehint)
         end
 
     elseif tag == ast.Exp.Concat then
-        for i, exp in ipairs(exp.exps) do
-            check_exp(exp, errors, nil)
-            local texp = exp._type
+        for _, inner_exp in ipairs(exp.exps) do
+            check_exp(inner_exp, errors, nil)
+            local texp = inner_exp._type
             if texp._tag ~= types.T.String then
-                type_error(errors, exp.loc,
+                type_error(errors, inner_exp.loc,
                     "cannot concatenate with %s value", types.tostring(texp))
             end
         end

--- a/titan-compiler/coder.lua
+++ b/titan-compiler/coder.lua
@@ -239,7 +239,7 @@ generate_program = function(prog, modname)
             tl_node._titan_entry_point =
                 mangle_function_name(modname, tl_node.name, "titan")
             tl_node._lua_entry_point =
-                mangle_function_name(modename, tl_node.name, "lua")
+                mangle_function_name(modname, tl_node.name, "lua")
         end
     end
 
@@ -253,31 +253,28 @@ generate_program = function(prog, modname)
                 assert(#tl_node._type.rettypes == 1)
                 local ret_ctype = ctype(tl_node._type.rettypes[1])
 
-                local args = {}
-                table.insert(args, [[lua_State * L]])
+                local titan_params = {}
+                table.insert(titan_params, [[lua_State * L]])
                 for _, param in ipairs(tl_node.params) do
                     local name = param.name
                     local typ  = param._type
-                    table.insert(args,
+                    table.insert(titan_params,
                         c_declaration(ctype(typ), local_name(name)))
                 end
 
                 table.insert(function_definitions,
                     util.render([[
-                        static ${RET} ${NAME}(${ARGS})
+                        static ${RET} ${NAME}(${PARAMS})
                         ${BODY}
                     ]], {
                         RET = ret_ctype,
                         NAME = tl_node._titan_entry_point,
-                        ARGS = table.concat(args, ", "),
+                        PARAMS = table.concat(titan_params, ", "),
                         BODY = generate_stat(tl_node.block)
                     })
                 )
 
                 -- Lua entry point
-                local lua_entry_point_name =
-                    mangle_function_name(modname, tl_node.name, "lua")
-
                 assert(#tl_node._type.rettypes == 1)
                 local ret_typ = tl_node._type.rettypes[1]
 

--- a/titan-compiler/parser.lua
+++ b/titan-compiler/parser.lua
@@ -479,8 +479,8 @@ function parser.parse(filename, input)
     return prog, errors
 end
 
-function parser.pretty_print_ast(ast)
-    return inspect(ast, {
+function parser.pretty_print_ast(prog)
+    return inspect(prog, {
         process = function(item, path)
             if path[#path] ~= inspect.METATABLE then
                 return item

--- a/titan-compiler/scope_analysis.lua
+++ b/titan-compiler/scope_analysis.lua
@@ -25,11 +25,11 @@ local bind_names_field
 -- @param prog AST for the whole module
 -- @return true or false, followed by a list of compilation errors
 function scope_analysis.bind_names(filename, input)
-    local ast, errors = parser.parse(filename, input)
-    if not ast then return false, errors end
+    local prog, errors = parser.parse(filename, input)
+    if not prog then return false, errors end
     local st = symtab.new()
-    bind_names_program(ast, st, errors)
-    return (#errors == 0 and ast), errors
+    bind_names_program(prog, st, errors)
+    return (#errors == 0 and prog), errors
 end
 
 

--- a/titan-compiler/util.lua
+++ b/titan-compiler/util.lua
@@ -45,7 +45,7 @@ end
 
 function util.shell(cmd)
     local p = io.popen(cmd)
-    out = p:read("*a")
+    local out = p:read("*a")
     p:close()
     return out
 end


### PR DESCRIPTION
Mostly shadowed variables, except for one case where it caught a typo (modename --> modname) and one time we were accidentally setting a global variable (out --> local out)