### PR TITLE
multiple return values from functions, plus multiple assignment

### DIFF
--- a/spec/checker_spec.lua
+++ b/spec/checker_spec.lua
@@ -1475,6 +1475,19 @@ describe("Titan type checker", function()
         assert_type_check([[
             function f()
                 local x: float = 10, 20, "foo"
+                x = 10, 20, "foo"
+            end
+        ]])
+    end)
+
+    it("typechecks multiple declarations and assignment", function()
+        assert_type_check([[
+            function g(): (integer, string)
+                return 20, "foo"
+            end
+            function f()
+                local x: float, y: integer, z: string = 10, g()
+                x = 10, g()
             end
         ]])
     end)
@@ -1503,6 +1516,23 @@ describe("Titan type checker", function()
             end
             function f()
                 local x: integer, y: string, z: integer = g()
+            end
+        ]],[[
+            function f()
+                local x: integer = 0
+                local y: string = ""
+                local z: integer = 0
+                x, y, z = 20, "foo"
+            end
+        ]],[[
+            function g(): (integer, string)
+                return 20, "foo"
+            end
+            function f()
+                local x: integer = 0
+                local y: string = ""
+                local z: integer = 0
+                x, y, z = g()
             end
         ]]}
         for _, c in ipairs(code) do

--- a/spec/checker_spec.lua
+++ b/spec/checker_spec.lua
@@ -501,6 +501,62 @@ describe("Titan type checker", function()
         end
     end)
 
+    it("checks return type against declared type for one return value", function()
+        local code = [[
+            function fn(): integer
+                return "foo"
+            end
+        ]]
+        local ok, err = run_checker(code)
+        assert.falsy(ok)
+        assert.match("types in return do not match", err)
+    end)
+
+    it("checks returning less values than function expects", function()
+        local code = [[
+            function fn(): (integer, string)
+                return 20
+            end
+        ]]
+        local ok, err = run_checker(code)
+        assert.falsy(ok)
+        assert.match("returned 1 value%(s%) but function expected 2", err)
+    end)
+
+    it("checks returning more values than function expects", function()
+        local code = [[
+            function fn(): (integer, string)
+                return 20, "foo", true
+            end
+        ]]
+        local ok, err = run_checker(code)
+        assert.falsy(ok)
+        assert.match("returned 3 value%(s%) but function expected 2", err)
+    end)
+
+    it("checks that returned values correctly match signature", function()
+        local code = [[
+            function fn(): (integer, string, boolean)
+                return 20, "foo", true
+            end
+        ]]
+        local ok, err = run_checker(code)
+        assert.truthy(ok)
+    end)
+
+    it("checks that returned values incorrectly match signature", function()
+        local code = [[
+            function fn(): (integer, string, string)
+                return "foo", true, 20
+            end
+        ]]
+        local ok, err = run_checker(code)
+        assert.falsy(ok)
+        assert.match("expected integer but found string", err)
+        assert.match("expected string but found boolean", err)
+        assert.match("expected string but found integer", err)
+    end)
+
     it("detects attempts to call non-functions", function()
         local code = [[
             function fn(): integer

--- a/spec/checker_spec.lua
+++ b/spec/checker_spec.lua
@@ -279,6 +279,37 @@ describe("Titan type checker", function()
         assert.truthy(ok, err)
     end)
 
+    it("typechecks multiple return values in array initialization", function ()
+        local code = [[
+            function f(): (integer, integer)
+                return 10, 20
+            end
+            function g(): (integer, string)
+                return 20, "foo"
+            end
+            function fn()
+                local arr: {integer} = { 10, g(), 30, f() }
+                local arr: {integer} = { 10, g(), 30, (g()) }
+            end
+        ]]
+        local ok, err = run_checker(code)
+        assert.truthy(ok, err)
+    end)
+
+    it("catches wrong type in multiple return values for array initialization", function ()
+        local code = [[
+            function g(): (integer, string)
+                return 20, "foo"
+            end
+            function fn()
+                local arr: {integer} = { 10, g() }
+            end
+        ]]
+        local ok, err = run_checker(code)
+        assert.falsy(ok)
+        assert.match("expected integer but found string", err)
+    end)
+
     it("catches named init list assigned to an array", function()
         local code = [[
             function fn(x: integer)

--- a/spec/checker_spec.lua
+++ b/spec/checker_spec.lua
@@ -1568,5 +1568,33 @@ describe("Titan typecheck of records", function()
             assert.match("expected integer but found string", err)
         end
     end)
+
+    it("typechecks extra values on right hand side", function()
+        assert_type_check([[
+            function f()
+                local x: float = 10, 20, "foo"
+            end
+        ]])
+    end)
+
+    it("catches too few values on right hand side", function()
+        local code = {[[
+            function f()
+                local x: integer, y: string, z: integer = 20, "foo"
+            end
+        ]],[[
+            function g(): (integer, string)
+                return 20, "foo"
+            end
+            function f()
+                local x: integer, y: string, z: integer = g()
+            end
+        ]]}
+        for _, c in ipairs(code) do
+            local ok, err = run_checker(c)
+            assert.falsy(ok)
+            assert.match("left%-hand side expects 3 value%(s%) but right%-hand side produces 2 value%(s%)", err)
+        end
+    end)
 end)
 

--- a/spec/checker_spec.lua
+++ b/spec/checker_spec.lua
@@ -1551,5 +1551,22 @@ describe("Titan typecheck of records", function()
         assert_type_error("expected Point but found float",
                           wrap_record[[ local p: Point = p.x ]])
     end)
+
+    it("catches local variable initialization with wrong type", function()
+        local code = {[[
+            function f()
+                local x: integer = "foo"
+            end
+        ]], [[
+            function f()
+                local x: integer, y: integer = 20, "foo"
+            end
+        ]]}
+        for _, c in ipairs(code) do
+            local ok, err = run_checker(c)
+            assert.falsy(ok)
+            assert.match("expected integer but found string", err)
+        end
+    end)
 end)
 

--- a/spec/checker_spec.lua
+++ b/spec/checker_spec.lua
@@ -89,8 +89,8 @@ describe("Titan type checker", function()
         ]]
         local ok, err, ast = run_checker(code)
         assert.truthy(ok)
-        assert.same("Ast.ExpCast", ast[1].block.stats[2].exp._tag)
-        assert.same("Type.Integer", ast[1].block.stats[2].exp.target._tag)
+        assert.same("Ast.ExpCast", ast[1].block.stats[2].exps[1]._tag)
+        assert.same("Type.Integer", ast[1].block.stats[2].exps[1].target._tag)
     end)
 
     it("coerces to float", function()
@@ -103,8 +103,8 @@ describe("Titan type checker", function()
         ]]
         local ok, err, ast = run_checker(code)
         assert.truthy(ok)
-        assert.same("Ast.ExpCast", ast[1].block.stats[2].exp._tag)
-        assert.same("Type.Float", ast[1].block.stats[2].exp.target._tag)
+        assert.same("Ast.ExpCast", ast[1].block.stats[2].exps[1]._tag)
+        assert.same("Type.Float", ast[1].block.stats[2].exps[1].target._tag)
     end)
 
     it("catches duplicate function declarations", function()
@@ -583,21 +583,21 @@ describe("Titan type checker", function()
             ]]
             local ok, err, ast = run_checker(code)
 
-            assert.same(types.Float(), ast[1].block.stats[3].exp.lhs._type)
-            assert.same(types.Float(), ast[1].block.stats[3].exp.rhs._type)
-            assert.same(types.Boolean(), ast[1].block.stats[3].exp._type)
+            assert.same(types.Float(), ast[1].block.stats[3].exps[1].lhs._type)
+            assert.same(types.Float(), ast[1].block.stats[3].exps[1].rhs._type)
+            assert.same(types.Boolean(), ast[1].block.stats[3].exps[1]._type)
 
-            assert.same(types.Float(), ast[1].block.stats[4].exp.lhs._type)
-            assert.same(types.Float(), ast[1].block.stats[4].exp.rhs._type)
-            assert.same(types.Boolean(), ast[1].block.stats[4].exp._type)
+            assert.same(types.Float(), ast[1].block.stats[4].exps[1].lhs._type)
+            assert.same(types.Float(), ast[1].block.stats[4].exps[1].rhs._type)
+            assert.same(types.Boolean(), ast[1].block.stats[4].exps[1]._type)
 
-            assert.same(types.Float(), ast[1].block.stats[5].exp.lhs._type)
-            assert.same(types.Float(), ast[1].block.stats[5].exp.rhs._type)
-            assert.same(types.Boolean(), ast[1].block.stats[5].exp._type)
+            assert.same(types.Float(), ast[1].block.stats[5].exps[1].lhs._type)
+            assert.same(types.Float(), ast[1].block.stats[5].exps[1].rhs._type)
+            assert.same(types.Boolean(), ast[1].block.stats[5].exps[1]._type)
 
-            assert.same(types.Integer(), ast[1].block.stats[6].exp.lhs._type)
-            assert.same(types.Integer(), ast[1].block.stats[6].exp.rhs._type)
-            assert.same(types.Boolean(), ast[1].block.stats[6].exp._type)
+            assert.same(types.Integer(), ast[1].block.stats[6].exps[1].lhs._type)
+            assert.same(types.Integer(), ast[1].block.stats[6].exps[1].rhs._type)
+            assert.same(types.Boolean(), ast[1].block.stats[6].exps[1]._type)
         end)
     end
 
@@ -615,21 +615,21 @@ describe("Titan type checker", function()
             ]]
             local ok, err, ast = run_checker(code)
 
-            assert.same(types.Float(), ast[1].block.stats[3].exp.lhs._type)
-            assert.same(types.Float(), ast[1].block.stats[3].exp.rhs._type)
-            assert.same(types.Float(), ast[1].block.stats[3].exp._type)
+            assert.same(types.Float(), ast[1].block.stats[3].exps[1].lhs._type)
+            assert.same(types.Float(), ast[1].block.stats[3].exps[1].rhs._type)
+            assert.same(types.Float(), ast[1].block.stats[3].exps[1]._type)
 
-            assert.same(types.Float(), ast[1].block.stats[4].exp.lhs._type)
-            assert.same(types.Float(), ast[1].block.stats[4].exp.rhs._type)
-            assert.same(types.Float(), ast[1].block.stats[4].exp._type)
+            assert.same(types.Float(), ast[1].block.stats[4].exps[1].lhs._type)
+            assert.same(types.Float(), ast[1].block.stats[4].exps[1].rhs._type)
+            assert.same(types.Float(), ast[1].block.stats[4].exps[1]._type)
 
-            assert.same(types.Float(), ast[1].block.stats[5].exp.lhs._type)
-            assert.same(types.Float(), ast[1].block.stats[5].exp.rhs._type)
-            assert.same(types.Float(), ast[1].block.stats[5].exp._type)
+            assert.same(types.Float(), ast[1].block.stats[5].exps[1].lhs._type)
+            assert.same(types.Float(), ast[1].block.stats[5].exps[1].rhs._type)
+            assert.same(types.Float(), ast[1].block.stats[5].exps[1]._type)
 
-            assert.same(types.Integer(), ast[1].block.stats[6].exp.lhs._type)
-            assert.same(types.Integer(), ast[1].block.stats[6].exp.rhs._type)
-            assert.same(types.Integer(), ast[1].block.stats[6].exp._type)
+            assert.same(types.Integer(), ast[1].block.stats[6].exps[1].lhs._type)
+            assert.same(types.Integer(), ast[1].block.stats[6].exps[1].rhs._type)
+            assert.same(types.Integer(), ast[1].block.stats[6].exps[1]._type)
         end)
     end
 
@@ -647,21 +647,21 @@ describe("Titan type checker", function()
             ]]
             local ok, err, ast = run_checker(code)
 
-            assert.same(types.Float(), ast[1].block.stats[3].exp.lhs._type)
-            assert.same(types.Float(), ast[1].block.stats[3].exp.rhs._type)
-            assert.same(types.Float(), ast[1].block.stats[3].exp._type)
+            assert.same(types.Float(), ast[1].block.stats[3].exps[1].lhs._type)
+            assert.same(types.Float(), ast[1].block.stats[3].exps[1].rhs._type)
+            assert.same(types.Float(), ast[1].block.stats[3].exps[1]._type)
 
-            assert.same(types.Float(), ast[1].block.stats[4].exp.lhs._type)
-            assert.same(types.Float(), ast[1].block.stats[4].exp.rhs._type)
-            assert.same(types.Float(), ast[1].block.stats[4].exp._type)
+            assert.same(types.Float(), ast[1].block.stats[4].exps[1].lhs._type)
+            assert.same(types.Float(), ast[1].block.stats[4].exps[1].rhs._type)
+            assert.same(types.Float(), ast[1].block.stats[4].exps[1]._type)
 
-            assert.same(types.Float(), ast[1].block.stats[5].exp.lhs._type)
-            assert.same(types.Float(), ast[1].block.stats[5].exp.rhs._type)
-            assert.same(types.Float(), ast[1].block.stats[5].exp._type)
+            assert.same(types.Float(), ast[1].block.stats[5].exps[1].lhs._type)
+            assert.same(types.Float(), ast[1].block.stats[5].exps[1].rhs._type)
+            assert.same(types.Float(), ast[1].block.stats[5].exps[1]._type)
 
-            assert.same(types.Integer(), ast[1].block.stats[6].exp.lhs._type)
-            assert.same(types.Integer(), ast[1].block.stats[6].exp.rhs._type)
-            assert.same(types.Integer(), ast[1].block.stats[6].exp._type)
+            assert.same(types.Integer(), ast[1].block.stats[6].exps[1].lhs._type)
+            assert.same(types.Integer(), ast[1].block.stats[6].exps[1].rhs._type)
+            assert.same(types.Integer(), ast[1].block.stats[6].exps[1]._type)
         end)
     end
 
@@ -679,21 +679,21 @@ describe("Titan type checker", function()
             ]]
             local ok, err, ast = run_checker(code)
 
-            assert.same(types.Integer(), ast[1].block.stats[3].exp.lhs._type)
-            assert.same(types.Integer(), ast[1].block.stats[3].exp.rhs._type)
-            assert.same(types.Integer(), ast[1].block.stats[3].exp._type)
+            assert.same(types.Integer(), ast[1].block.stats[3].exps[1].lhs._type)
+            assert.same(types.Integer(), ast[1].block.stats[3].exps[1].rhs._type)
+            assert.same(types.Integer(), ast[1].block.stats[3].exps[1]._type)
 
-            assert.same(types.Integer(), ast[1].block.stats[4].exp.lhs._type)
-            assert.same(types.Integer(), ast[1].block.stats[4].exp.rhs._type)
-            assert.same(types.Integer(), ast[1].block.stats[4].exp._type)
+            assert.same(types.Integer(), ast[1].block.stats[4].exps[1].lhs._type)
+            assert.same(types.Integer(), ast[1].block.stats[4].exps[1].rhs._type)
+            assert.same(types.Integer(), ast[1].block.stats[4].exps[1]._type)
 
-            assert.same(types.Integer(), ast[1].block.stats[5].exp.lhs._type)
-            assert.same(types.Integer(), ast[1].block.stats[5].exp.rhs._type)
-            assert.same(types.Integer(), ast[1].block.stats[5].exp._type)
+            assert.same(types.Integer(), ast[1].block.stats[5].exps[1].lhs._type)
+            assert.same(types.Integer(), ast[1].block.stats[5].exps[1].rhs._type)
+            assert.same(types.Integer(), ast[1].block.stats[5].exps[1]._type)
 
-            assert.same(types.Integer(), ast[1].block.stats[6].exp.lhs._type)
-            assert.same(types.Integer(), ast[1].block.stats[6].exp.rhs._type)
-            assert.same(types.Integer(), ast[1].block.stats[6].exp._type)
+            assert.same(types.Integer(), ast[1].block.stats[6].exps[1].lhs._type)
+            assert.same(types.Integer(), ast[1].block.stats[6].exps[1].rhs._type)
+            assert.same(types.Integer(), ast[1].block.stats[6].exps[1]._type)
         end)
     end
 
@@ -711,21 +711,21 @@ describe("Titan type checker", function()
             ]]
             local ok, err, ast = run_checker(code)
 
-            assert.same(types.Float(), ast[1].block.stats[3].exp.lhs._type)
-            assert.same(types.Float(), ast[1].block.stats[3].exp.rhs._type)
-            assert.same(types.Float(), ast[1].block.stats[3].exp._type)
+            assert.same(types.Float(), ast[1].block.stats[3].exps[1].lhs._type)
+            assert.same(types.Float(), ast[1].block.stats[3].exps[1].rhs._type)
+            assert.same(types.Float(), ast[1].block.stats[3].exps[1]._type)
 
-            assert.same(types.Float(), ast[1].block.stats[4].exp.lhs._type)
-            assert.same(types.Float(), ast[1].block.stats[4].exp.rhs._type)
-            assert.same(types.Float(), ast[1].block.stats[4].exp._type)
+            assert.same(types.Float(), ast[1].block.stats[4].exps[1].lhs._type)
+            assert.same(types.Float(), ast[1].block.stats[4].exps[1].rhs._type)
+            assert.same(types.Float(), ast[1].block.stats[4].exps[1]._type)
 
-            assert.same(types.Float(), ast[1].block.stats[5].exp.lhs._type)
-            assert.same(types.Float(), ast[1].block.stats[5].exp.rhs._type)
-            assert.same(types.Float(), ast[1].block.stats[5].exp._type)
+            assert.same(types.Float(), ast[1].block.stats[5].exps[1].lhs._type)
+            assert.same(types.Float(), ast[1].block.stats[5].exps[1].rhs._type)
+            assert.same(types.Float(), ast[1].block.stats[5].exps[1]._type)
 
-            assert.same(types.Float(), ast[1].block.stats[6].exp.lhs._type)
-            assert.same(types.Float(), ast[1].block.stats[6].exp.rhs._type)
-            assert.same(types.Float(), ast[1].block.stats[6].exp._type)
+            assert.same(types.Float(), ast[1].block.stats[6].exps[1].lhs._type)
+            assert.same(types.Float(), ast[1].block.stats[6].exps[1].rhs._type)
+            assert.same(types.Float(), ast[1].block.stats[6].exps[1]._type)
         end)
     end
 

--- a/spec/checker_spec.lua
+++ b/spec/checker_spec.lua
@@ -520,18 +520,17 @@ describe("Titan type checker", function()
         ]]
         local ok, err = run_checker(code)
         assert.falsy(ok)
-        assert.match("returned 1 value%(s%) but function expected 2", err)
+        assert.match("returned just 1 value%(s%) but function expected 2", err)
     end)
 
-    it("checks returning more values than function expects", function()
+    it("typechecks returning more values than function expects", function()
         local code = [[
             function fn(): (integer, string)
                 return 20, "foo", true
             end
         ]]
         local ok, err = run_checker(code)
-        assert.falsy(ok)
-        assert.match("returned 3 value%(s%) but function expected 2", err)
+        assert.truthy(ok)
     end)
 
     it("checks that returned values correctly match signature", function()

--- a/spec/coder_spec.lua
+++ b/spec/coder_spec.lua
@@ -794,7 +794,7 @@ describe("Titan code generator", function()
             assert.truthy(ast, err)
             local ok, err = checker.check("test", ast, code, "test.titan")
             assert.truthy(ok)
-            assert.are.same(#err, 0)
+            assert.are.same(0, #err)
             local ok, err = driver.compile("titan_test", ast)
             assert.truthy(ok, err)
             local code = 'local x = titan_test.fn(); assert(' .. test .. ')'

--- a/spec/coder_spec.lua
+++ b/spec/coder_spec.lua
@@ -1078,6 +1078,38 @@ describe("Titan code generator", function()
         ]])
         assert.truthy(ok, err)
     end)
+
+    it("handles multiple return values in array initialization", function ()
+        local code = [[
+            function f(): (integer, integer)
+                return 40, 50
+            end
+            function g(): (integer, string)
+                return 20, "foo"
+            end
+            function fn(): {integer}
+                local arr: {integer} = { 10, g(), 30, f() }
+                return arr
+            end
+        ]]
+        local ast, err = parse(code)
+        assert.truthy(ast, err)
+        local ok, err = checker.check("test", ast, code, "test.titan")
+        assert.truthy(ok, err)
+        local ok, err = driver.compile("titan_test", ast)
+        assert.truthy(ok, err)
+        local ok, err = call("titan_test", [[
+            local arr = titan_test.fn()
+            assert(5 == #arr)
+            assert(10 == arr[1])
+            assert(20 == arr[2])
+            assert(30 == arr[3])
+            assert(40 == arr[4])
+            assert(50 == arr[5])
+        ]])
+        assert.truthy(ok, err)
+    end)
+
 end)
 
 

--- a/spec/parser_spec.lua
+++ b/spec/parser_spec.lua
@@ -392,14 +392,39 @@ describe("Titan parser", function()
             { _tag = "Ast.StatBlock",
                 stats = {
                     { _tag = "Ast.StatDecl",
-                        decl = { name = "x" },
-                        exp = { value = 10 } },
+                        decls = {{ name = "x" }},
+                        exps = {{ value = 10 }} },
                     { _tag = "Ast.StatAssign",
                         var = { name = "x" },
                         exp = { value = 11 } },
                     { _tag = "Ast.StatCall",
                         callexp = { _tag = "Ast.ExpCall" } } } },
         })
+    end)
+
+    it("can parse multiple variable declaration", function()
+        assert_statements_ast([[
+            local x, y = 10, 20
+        ]], {
+            { _tag = "Ast.StatDecl",
+                        decls = {{ name = "x" }, { name = "y" }},
+                        exps = {{ value = 10 }, { value = 20 }} }
+        })
+    end)
+
+    it("requires lhs and rhs of local variable declaration", function()
+        assert_statements_syntax_error([[
+            local  = 10
+        ]], "DeclLocal")
+        assert_statements_syntax_error([[
+            local x, = 10, 20
+        ]], "DeclParList")
+        assert_statements_syntax_error([[
+            local x =
+        ]], "ExpLocal")
+        assert_statements_syntax_error([[
+            local x, y = 10,
+        ]], "ExpExpList")
     end)
 
     it("can parse numeric for loops", function()

--- a/spec/parser_spec.lua
+++ b/spec/parser_spec.lua
@@ -423,16 +423,16 @@ describe("Titan parser", function()
 
     it("can parse return statements", function()
         assert_statements_ast("return", {
-            { _tag = "Ast.StatReturn", exp = false }})
+            { _tag = "Ast.StatReturn", exps = {} }})
 
         assert_statements_ast("return;", {
-            { _tag = "Ast.StatReturn", exp = false }})
+            { _tag = "Ast.StatReturn", exps = {} }})
 
         assert_statements_ast("return x", {
-            { _tag = "Ast.StatReturn", exp = { _tag = "Ast.ExpVar" } },
+            { _tag = "Ast.StatReturn", exps = {{ _tag = "Ast.ExpVar" }} },
         })
         assert_statements_ast("return x;", {
-            { _tag = "Ast.StatReturn", exp = { _tag = "Ast.ExpVar" } },
+            { _tag = "Ast.StatReturn", exps = {{ _tag = "Ast.ExpVar" }} },
         })
     end)
 

--- a/spec/parser_spec.lua
+++ b/spec/parser_spec.lua
@@ -434,6 +434,12 @@ describe("Titan parser", function()
         assert_statements_ast("return x;", {
             { _tag = "Ast.StatReturn", exps = {{ _tag = "Ast.ExpVar" }} },
         })
+        assert_statements_ast("return x, y", {
+            { _tag = "Ast.StatReturn", exps = {{ _tag = "Ast.ExpVar" },{ _tag = "Ast.ExpVar" }} },
+        })
+        assert_statements_ast("return x, y;", {
+            { _tag = "Ast.StatReturn", exps = {{ _tag = "Ast.ExpVar" },{ _tag = "Ast.ExpVar" }} },
+        })
     end)
 
     it("requires that return statements be the last in the block", function()
@@ -447,6 +453,20 @@ describe("Titan parser", function()
         assert_statements_syntax_error([[
             return;;
         ]], "EndFunc")
+    end)
+
+    it("can parse parenthesis around calls", function()
+        assert_expression_ast([[ (f()) ]],
+            { _tag = "Ast.ExpAdjust", exp = { _tag = "Ast.ExpCall" } })
+
+        assert_expression_ast([[ ((f())) ]],
+            { _tag = "Ast.ExpAdjust", exp = { _tag = "Ast.ExpCall" } })
+
+        assert_expression_ast([[ (o:m ()) ]],
+            { _tag = "Ast.ExpAdjust", exp = { _tag = "Ast.ExpCall" } })
+
+        assert_expression_ast([[ ((o:m ())) ]],
+            { _tag = "Ast.ExpAdjust", exp = { _tag = "Ast.ExpCall" } })
     end)
 
     it("can parse binary and unary operators", function()

--- a/titan-compiler/ast.lua
+++ b/titan-compiler/ast.lua
@@ -30,7 +30,7 @@ return typedecl("Ast", {
         StatRepeat      = {"loc", "block", "condition"},
         StatIf          = {"loc", "thens", "elsestat"},
         StatFor         = {"loc", "decl", "start", "finish", "inc", "block"},
-        StatAssign      = {"loc", "var", "exp"},
+        StatAssign      = {"loc", "vars", "exps"},
         StatDecl        = {"loc", "decls", "exps"},
         StatCall        = {"loc", "callexp"},
         StatReturn      = {"loc", "exps"},

--- a/titan-compiler/ast.lua
+++ b/titan-compiler/ast.lua
@@ -59,7 +59,8 @@ return typedecl("Ast", {
         ExpConcat       = {"loc", "exps"},
         ExpBinop        = {"loc", "lhs", "op", "rhs"},
         ExpCast         = {"loc", "exp", "target"},
-        ExpAdjust       = {"loc", "exp"}
+        ExpAdjust       = {"loc", "exp"},                   -- adjust call to just first value
+        ExpExtra        = {"loc", "exp", "index", "_type"}  -- index-th (>1) value of call
     },
 
     Args = {

--- a/titan-compiler/ast.lua
+++ b/titan-compiler/ast.lua
@@ -33,7 +33,7 @@ return typedecl("Ast", {
         StatAssign      = {"loc", "var", "exp"},
         StatDecl        = {"loc", "decl", "exp"},
         StatCall        = {"loc", "callexp"},
-        StatReturn      = {"loc", "exp"},
+        StatReturn      = {"loc", "exps"},
     },
 
     Then = {
@@ -58,7 +58,8 @@ return typedecl("Ast", {
         ExpUnop         = {"loc", "op", "exp"},
         ExpConcat       = {"loc", "exps"},
         ExpBinop        = {"loc", "lhs", "op", "rhs"},
-        ExpCast         = {"loc", "exp", "target"}
+        ExpCast         = {"loc", "exp", "target"},
+        ExpAdjust       = {"loc", "exp"}
     },
 
     Args = {

--- a/titan-compiler/ast.lua
+++ b/titan-compiler/ast.lua
@@ -31,7 +31,7 @@ return typedecl("Ast", {
         StatIf          = {"loc", "thens", "elsestat"},
         StatFor         = {"loc", "decl", "start", "finish", "inc", "block"},
         StatAssign      = {"loc", "var", "exp"},
-        StatDecl        = {"loc", "decl", "exp"},
+        StatDecl        = {"loc", "decls", "exps"},
         StatCall        = {"loc", "callexp"},
         StatReturn      = {"loc", "exps"},
     },

--- a/titan-compiler/checker.lua
+++ b/titan-compiler/checker.lua
@@ -520,6 +520,15 @@ checkexp = util.make_visitor({
             table.insert(etypes, exp._type)
             isarray = isarray and not field.name
         end
+        local lastfield = node.fields[#node.fields]
+        if lastfield and not lastfield.name and lastfield.exp._types and #lastfield.exp._types > 1 then
+            for i = 2, #lastfield.exp._types do
+                table.insert(node.fields,
+                    ast.Field(lastfield.loc, nil,
+                        ast.ExpExtra(lastfield.loc, lastfield.exp,
+                            i, lastfield.exp._types[i])))
+            end
+        end
         if isarray then
             local etype = econtext or etypes[1] or types.Integer()
             node._type = types.Array(etype)

--- a/titan-compiler/checker.lua
+++ b/titan-compiler/checker.lua
@@ -756,6 +756,7 @@ checkexp = util.make_visitor({
             end
             assert(#ftype.rettypes == 1)
             node._type = ftype.rettypes[1]
+            node._types = ftype.rettypes
         else
             checker.typeerror(errors, node.loc,
                 "'%s' is not a function but %s",

--- a/titan-compiler/checker.lua
+++ b/titan-compiler/checker.lua
@@ -136,6 +136,9 @@ end
 
 checkdecl = function(node, st, errors)
     node._type = node._type or typefromnode(node.type, st, errors)
+end
+
+local function declare(node, st)
     st:add_symbol(node.name, node)
 end
 
@@ -173,9 +176,10 @@ local function checkfor(node, st, errors)
         node.decl._type = node.start._type
     end
     checkdecl(node.decl, st, errors)
+    declare(node.decl, st)
 
     local loop_type_is_valid
-    if     node.decl._type._tag == "Type.Integer" then
+    if node.decl._type._tag == "Type.Integer" then
         loop_type_is_valid = true
         if not node.inc then
             node.inc = ast.ExpInteger(node.finish.loc, 1)
@@ -255,6 +259,9 @@ checkstat = util.make_visitor({
             elseif exp then
                 checkexp(exp, st, errors)
             end
+        end
+        for _, decl in ipairs(node.decls) do
+            declare(decl, st)
         end
     end,
 

--- a/titan-compiler/checker.lua
+++ b/titan-compiler/checker.lua
@@ -295,21 +295,24 @@ checkstat = util.make_visitor({
     end,
 
     ["Ast.StatAssign"] = function(node, st, errors)
-        checkvar(node.var, st, errors)
-        checkexp(node.exp, st, errors, node.var._type)
-        local texp = node.var._type
+        local var = node.vars[1]
+        local exp = node.exps[1]
+        checkvar(var, st, errors)
+        checkexp(exp, st, errors, var._type)
+        local texp = var._type
         if texp._tag == "Type.Module" then
-            checker.typeerror(errors, node.loc, "trying to assign to a module")
+            checker.typeerror(errors, var.loc, "trying to assign to a module")
         elseif texp._tag == "Type.Function" then
-            checker.typeerror(errors, node.loc, "trying to assign to a function")
+            checker.typeerror(errors, var.loc, "trying to assign to a function")
         else
             -- mark this declared variable as assigned to
-            if node.var._tag == "Ast.VarName" and node.var._decl then
-                node.var._decl._assigned = true
+            if var._tag == "Ast.VarName" and var._decl then
+                var._decl._assigned = true
             end
-            node.exp = trycoerce(node.exp, node.var._type, errors)
-            if node.var._tag ~= "Ast.VarBracket" or node.exp._type._tag ~= "Type.Nil" then
-                checkmatch("assignment", node.var._type, node.exp._type, errors, node.var.loc)
+            exp = trycoerce(exp, var._type, errors)
+            node.exps[1] = exp
+            if var._tag ~= "Ast.VarBracket" or exp._type._tag ~= "Type.Nil" then
+                checkmatch("assignment", var._type, exp._type, errors, var.loc)
             end
         end
     end,

--- a/titan-compiler/coder.lua
+++ b/titan-compiler/coder.lua
@@ -643,9 +643,9 @@ local function codecall(ctx, node)
 end
 
 local function codereturn(ctx, node)
-    local cstats, cexp = codeexp(ctx, node.exp)
+    local cstats, cexp = codeexp(ctx, node.exps[1])
     local tmpl
-    if types.is_gc(node.exp._type) then
+    if types.is_gc(node.exps[1]._type) then
         return render([[
             $CSTATS
             $CTYPE ret = $CEXP;
@@ -656,8 +656,8 @@ local function codereturn(ctx, node)
         ]], {
             CSTATS = cstats,
             CEXP = cexp,
-            CTYPE = ctype(node.exp._type),
-            SETSLOT = setslot(node.exp._type, "_retslot", "ret")
+            CTYPE = ctype(node.exps[1]._type),
+            SETSLOT = setslot(node.exps[1]._type, "_retslot", "ret")
         })
     elseif ctx.nslots > 0 then
         tmpl = [[
@@ -1198,6 +1198,8 @@ function codeexp(ctx, node, iscondition, target)
             TMPSLOT = tmpslot,
         })
         return code, tmpname
+    elseif tag == "Ast.ExpAdjust" then
+        codeexp(ctx, node.exp, iscondition, target)
     else
         error("invalid node tag " .. tag)
     end

--- a/titan-compiler/coder.lua
+++ b/titan-compiler/coder.lua
@@ -697,21 +697,25 @@ end
 function codestat(ctx, node)
     local tag = node._tag
     if tag == "Ast.StatDecl" then
-        local cstats, cexp = codeexp(ctx, node.exp)
-        if node.decl._used then
-            local typ = node.decl._type
-            node.decl._cvar = "_local_" .. node.decl.name
-            local cdecl = ctype(typ) .. " " .. node.decl._cvar .. ";"
+        assert(#node.exps == 1)
+        assert(#node.decls == 1)
+        local exp = node.exps[1]
+        local decl = node.decls[1]
+        local cstats, cexp = codeexp(ctx, exp)
+        if decl._used then
+            local typ = decl._type
+            decl._cvar = "_local_" .. decl.name
+            local cdecl = ctype(typ) .. " " .. decl._cvar .. ";"
             local cslot = ""
             local cset = ""
             if types.is_gc(typ) then
-                node.decl._slot = "_localslot_" .. node.decl.name
-                cslot = newslot(ctx, node.decl._slot);
+                decl._slot = "_localslot_" .. decl.name
+                cslot = newslot(ctx, decl._slot);
                 cset = render([[
                     /* update slot */
                     $SETSLOT
                 ]], {
-                    SETSLOT = setslot(typ, node.decl._slot, node.decl._cvar),
+                    SETSLOT = setslot(typ, decl._slot, decl._cvar),
                 })
             end
             return render([[
@@ -726,7 +730,7 @@ function codestat(ctx, node)
                 CDECL = cdecl,
                 CSLOT = cslot,
                 CSTATS = cstats,
-                CVAR = node.decl._cvar,
+                CVAR = decl._cvar,
                 CEXP = cexp,
                 CSET = cset
             })

--- a/titan-compiler/parser.lua
+++ b/titan-compiler/parser.lua
@@ -81,6 +81,14 @@ function defs.name_exp(pos, name)
     return ast.ExpVar(pos, ast.VarName(pos, name))
 end
 
+function defs.adjust_exp(pos, exp)
+    if exp._tag == "Ast.ExpCall" then
+        return ast.ExpAdjust(pos, exp)
+    else
+        return exp
+    end
+end
+
 function defs.ifstat(pos, exp, block, thens, elseopt)
     table.insert(thens, 1, ast.Then(pos, exp, block))
     return ast.StatIf(pos, thens, elseopt)
@@ -284,7 +292,7 @@ local grammar = re.compile([[
 
     elseopt         <- (ELSE block)?                             -> opt
 
-    returnstat      <- (P  RETURN (exp? -> opt) SEMICOLON?)      -> StatReturn
+    returnstat      <- (P  RETURN (explist? -> opt) SEMICOLON?)      -> StatReturn
 
     op1             <- ( OR -> 'or' )
     op2             <- ( AND -> 'and' )
@@ -324,8 +332,8 @@ local grammar = re.compile([[
                      / (P  DOT NAME^NameDotExpSuf)               -> suffix_dot
 
     prefixexp       <- (P  NAME)                                 -> name_exp
-                     / (LPAREN exp^ExpSimpleExp
-                               RPAREN^RParSimpleExp)             -- produces Exp
+                     / (P  LPAREN exp^ExpSimpleExp
+                               RPAREN^RParSimpleExp)             -> adjust_exp
 
 
     castexp         <- (P  simpleexp AS type^CastMissingType)    -> ExpCast

--- a/titan-compiler/parser.lua
+++ b/titan-compiler/parser.lua
@@ -290,8 +290,8 @@ local grammar = re.compile([[
                            DO^DoFor block END^EndFor)            -> StatFor
                      / (P  LOCAL decllist^DeclLocal ASSIGN^AssignLocal
                                  explist^ExpLocal)                   -> StatDecl
-                     / (P  var ASSIGN^AssignAssign
-                               exp^ExpAssign)                    -> StatAssign
+                     / (P  varlist ASSIGN^AssignAssign
+                               explist^ExpAssign)                    -> StatAssign
                      / &(exp ASSIGN) %{ExpAssign}
                      / (P  (suffixedexp => exp_is_call))         -> StatCall
                      / &exp %{ExpStat}
@@ -361,6 +361,8 @@ local grammar = re.compile([[
 
     var             <- (suffixedexp => exp_is_var)               -> exp2var
                      / (P  NAME !expsuffix)                      -> name_exp -> exp2var
+
+    varlist         <- {| var (COMMA var^ExpVarList)* |}            -- produces {Var}
 
     funcargs        <- (LPAREN (explist? -> listopt) RPAREN^RParFuncArgs)      -- produces {Exp}
                      / {| initlist |}                            -- produces {Exp}

--- a/titan-compiler/syntax_errors.lua
+++ b/titan-compiler/syntax_errors.lua
@@ -153,6 +153,8 @@ local errors = {
 
     ExpExpList = "Expected an expression after ','.",
 
+    ExpVarList = "Expected a destination for an assignment after ','.",
+
     RCurlyInitList = "Expected '{' to match '}'.",
 
     ExpFieldList = "Expected an expression after ',' or ';'.",
@@ -165,6 +167,6 @@ local errors = {
 
 }
 
-syntax_errors.errors = errors 
+syntax_errors.errors = errors
 
 return syntax_errors

--- a/titan-compiler/util.lua
+++ b/titan-compiler/util.lua
@@ -56,4 +56,13 @@ function util.curry(f, a)
     end
 end
 
+function util.any(f, l)
+    for _, elem in ipairs(l) do
+        if f(l) then
+            return true
+        end
+    end
+    return false
+end
+
 return util

--- a/titan-compiler/util.lua
+++ b/titan-compiler/util.lua
@@ -31,7 +31,7 @@ function util.render(code, substs)
     return (string.gsub(code, "$([%w_]+)", function(k)
         local v = substs[k]
         if not v then
-            error("Internal compiler error: missing template variable " .. k)
+            error("Internal compiler error: missing template variable " .. k .. "\n" .. code)
         end
         return v
     end))
@@ -58,7 +58,7 @@ end
 
 function util.any(f, l)
     for _, elem in ipairs(l) do
-        if f(l) then
+        if f(elem) then
             return true
         end
     end


### PR DESCRIPTION
Right now just a stub, with a new `Ast.ExpAdjust` node for parenthesized function calls, plus changing `Ast.StatReturn` to take an expression list. The typechecker complains if the number of expressions in this expression list is different from the number of return types, not taking into account the last expression returning multiple values right now. The code generator just generates code for the first return expresssion, enough to make our current tests pass.

Roadmap: 

* [x] fix typechecker to take into account trailing calls in expression lists, both in `StatReturn` and in the argument lists of `ExpCall`
* [x] make code generator generate proper signatures for functions with multiple return values, and make `StatReturn` work with them
* [x] add multiple local variable declaration, and make it interact with multiple return values; multiple declaration is lenient with extra returned values
* [x] fix code generation for argument lists to take multiple return values in the trailing position and pass them along; maintain strict arity check
* [ ] add multiple assignment, and make it interact with multiple return values; multiple assignment is lenient with extra returned values
* [x] use multiple return values in array constructors' expression lists