### PR TITLE
Implement functions with zero return values

### DIFF
--- a/spec/checker_spec.lua
+++ b/spec/checker_spec.lua
@@ -738,12 +738,11 @@ describe("Titan type checker", function()
             end
 
             local function g(): integer
-                local x = 1 + f()
-                return x
+                return 1 + f()
             end
         ]])
         assert.falsy(prog)
-        assert.match("expected integer but found invalid type", errs)
+        assert.match("void instead of a number", errs)
     end)
 
     it("detects attempts to call non-functions", function()

--- a/spec/checker_spec.lua
+++ b/spec/checker_spec.lua
@@ -642,8 +642,48 @@ describe("Titan type checker", function()
         assert.match("'for' step expression", errs)
     end)
 
-    it("detects when a functionr returns the wrong type", function()
-        local code, errors = run_checker([[
+    it("detects wrong number of return values", function()
+        local prog, errs = run_checker([[
+            function f(): ()
+                return 1
+            end
+        ]])
+        assert.falsy(prog)
+        assert.match(
+            "returning 1 value(s) but function expects 0", errs,
+            nil, true)
+
+        local prog, errs = run_checker([[
+            function f(): integer
+                return
+            end
+        ]])
+        assert.falsy(prog)
+        assert.match(
+            "returning 0 value(s) but function expects 1", errs,
+            nil, true)
+    end)
+
+    it("accepts functions that return 0 values", function()
+        local prog, errors = run_checker([[
+            function f(): ()
+                return
+            end
+        ]])
+        assert.truthy(prog)
+    end)
+
+    it("accepts functions that return 1 value", function()
+        local prog, errors = run_checker([[
+            function f(): integer
+                return 17
+            end
+        ]])
+        assert.truthy(prog)
+    end)
+
+    it("detects when a function returns the wrong type", function()
+        local prog, errors = run_checker([[
             function fn(): integer
                 return "hello"
             end
@@ -652,7 +692,7 @@ describe("Titan type checker", function()
         assert.match("types in return statement do not match, expected integer but found string", errors)
     end)
 
-    it("detects nil returns on non-nil functions", function()
+    it("detects missing return statements", function()
         local code = {[[
             function fn(): integer
             end
@@ -688,8 +728,22 @@ describe("Titan type checker", function()
         for _, c in ipairs(code) do
             local prog, errs = run_checker(c)
             assert.falsy(prog)
-            assert.match("control reaches end of function with non%-nil return type", errs)
+            assert.match("control reaches end of function with non%-empty return type", errs)
         end
+    end)
+
+    it("rejects void functions in expression contexts", function()
+        local prog, errs = run_checker([[
+            local function f(): ()
+            end
+
+            local function g(): integer
+                local x = 1 + f()
+                return x
+            end
+        ]])
+        assert.falsy(prog)
+        assert.match("expected integer but found invalid type", errs)
     end)
 
     it("detects attempts to call non-functions", function()
@@ -707,7 +761,7 @@ describe("Titan type checker", function()
     for _, op in ipairs({"+", "-", "*", "%", "//"}) do
         it("coerces "..op.." to float if any side is a float", function()
             local code = [[
-                function fn(): nil
+                function fn()
                     local i: integer = 1
                     local f: float = 1.5
                     local i_f = i ]] .. op .. [[ f
@@ -740,7 +794,7 @@ describe("Titan type checker", function()
     for _, op in ipairs({"/", "^"}) do
         it("always coerces "..op.." to float", function()
             local code = [[
-                function fn(): nil
+                function fn()
                     local i: integer = 1
                     local f: float = 1.5
                     local i_f = i ]] .. op .. [[ f

--- a/spec/coder_spec.lua
+++ b/spec/coder_spec.lua
@@ -155,6 +155,9 @@ describe("Titan coder", function()
                 local x = 10
 
                 function incr(): ()
+                    if x >= 100 then
+                        return
+                    end
                     x = x + 1
                 end
 

--- a/spec/coder_spec.lua
+++ b/spec/coder_spec.lua
@@ -150,6 +150,23 @@ describe("Titan coder", function()
             ]])
         end)
 
+        it("Function calls (void functions)", function()
+            run_coder([[
+                local x = 10
+
+                function incr(): ()
+                    x = x + 1
+                end
+
+                function f(): integer
+                    incr()
+                    return x
+                end
+            ]], [[
+                assert(11 == test.f())
+            ]])
+        end)
+
         describe("Vars", function()
             it("Local variables", function()
                 run_coder([[
@@ -667,9 +684,8 @@ describe("Titan coder", function()
                 return arr[i]
             end
 
-            function set(arr: {integer}, i: integer, v: integer): nil
+            function set(arr: {integer}, i: integer, v: integer)
                 arr[i] = v
-                return nil
             end
         ]]
 

--- a/spec/parser_spec.lua
+++ b/spec/parser_spec.lua
@@ -199,8 +199,8 @@ describe("Titan parser", function()
             local function bar()
             end
         ]], {
-            { _tag = ast.Toplevel.Func, name = "foo", rettypes = { { _tag = ast.Type.Nil } } },
-            { _tag = ast.Toplevel.Func, name = "bar", rettypes = { { _tag = ast.Type.Nil } } },
+            { _tag = ast.Toplevel.Func, name = "foo", rettypes = { } },
+            { _tag = ast.Toplevel.Func, name = "bar", rettypes = { } },
         })
     end)
 

--- a/spec/parser_spec.lua
+++ b/spec/parser_spec.lua
@@ -422,16 +422,16 @@ describe("Titan parser", function()
 
     it("can parse return statements", function()
         assert_statements_ast("return", {
-            { _tag = ast.Stat.Return, exp = false }})
+            { _tag = ast.Stat.Return, exps = {} }})
 
         assert_statements_ast("return;", {
-            { _tag = ast.Stat.Return, exp = false }})
+            { _tag = ast.Stat.Return, exps = {} }})
 
         assert_statements_ast("return x", {
-            { _tag = ast.Stat.Return, exp = { _tag = ast.Exp.Var } },
+            { _tag = ast.Stat.Return, exps = { { _tag = ast.Exp.Var } } },
         })
         assert_statements_ast("return x;", {
-            { _tag = ast.Stat.Return, exp = { _tag = ast.Exp.Var } },
+            { _tag = ast.Stat.Return, exps = { { _tag = ast.Exp.Var } } },
         })
     end)
 

--- a/spec/scope_analysis_spec.lua
+++ b/spec/scope_analysis_spec.lua
@@ -17,7 +17,7 @@ describe("Scope analysis: ", function()
         assert.truthy(prog)
         assert.are.equal(
             prog[1], -- x
-            prog[2].block.stats[1].exp.var._decl)
+            prog[2].block.stats[1].exps[1].var._decl)
     end)
 
     it("function parameters work", function()
@@ -29,7 +29,7 @@ describe("Scope analysis: ", function()
         assert.truthy(prog)
         assert.are.equal(
             prog[1].params[1], -- x
-            prog[1].block.stats[1].exp.var._decl)
+            prog[1].block.stats[1].exps[1].var._decl)
     end)
 
     it("local variables work", function()
@@ -42,7 +42,7 @@ describe("Scope analysis: ", function()
         assert.truthy(prog)
         assert.are.equal(
             prog[1].block.stats[1].decl, -- x
-            prog[1].block.stats[2].exp.var._decl)
+            prog[1].block.stats[2].exps[1].var._decl)
     end)
 
     it("functions can be recursive", function()
@@ -58,7 +58,7 @@ describe("Scope analysis: ", function()
         assert.truthy(prog)
         assert.are.equal(
             prog[1], -- fac
-            prog[1].block.stats[1].elsestat.stats[1].exp.rhs.exp.var._decl)
+            prog[1].block.stats[1].elsestat.stats[1].exps[1].rhs.exp.var._decl)
     end)
 
     it("forbids variables from being used before they are defined", function()
@@ -118,7 +118,7 @@ describe("Scope analysis: ", function()
             prog[2].block.stats[1].decl.type._decl)
         assert.are.equal(
             prog[2].block.stats[1].decl, -- local x
-            prog[2].block.stats[2].exp.var.exp.var._decl)
+            prog[2].block.stats[2].exps[1].var.exp.var._decl)
     end)
 
     it("local variable scope doesn't shadow its initializer", function()
@@ -135,7 +135,7 @@ describe("Scope analysis: ", function()
             prog[2].block.stats[1].exp.lhs.var._decl)
         assert.are.equal(
             prog[2].block.stats[1].decl, -- local x
-            prog[2].block.stats[2].exp.var._decl)
+            prog[2].block.stats[2].exps[1].var._decl)
     end)
 
     it("repeat-until scope includes the condition", function()
@@ -173,7 +173,7 @@ describe("Scope analysis: ", function()
             prog[2].block.stats[1].decl.type._decl)
         assert.are.equal(
             prog[2].block.stats[1].decl, -- local x
-            prog[2].block.stats[1].block.stats[1].exp.var._decl)
+            prog[2].block.stats[1].block.stats[1].exps[1].var._decl)
     end)
 
     it("for loop variable scope doesn't shadow its initializers", function()
@@ -197,7 +197,7 @@ describe("Scope analysis: ", function()
             prog[1].block.stats[2].inc.var._decl)
         assert.are.equal(
             prog[1].block.stats[2].decl, -- for x
-            prog[1].block.stats[2].block.stats[1].exp.var._decl)
+            prog[1].block.stats[2].block.stats[1].exps[1].var._decl)
     end)
 
     it("allows recursive functions", function()
@@ -213,7 +213,7 @@ describe("Scope analysis: ", function()
         assert.truthy(prog)
         assert.are.equal(
             prog[1], -- fat
-            prog[1].block.stats[1].elsestat.stats[1].exp.rhs.exp.var._decl)
+            prog[1].block.stats[1].elsestat.stats[1].exps[1].rhs.exp.var._decl)
     end)
 
     it("forbids mutually recursive definitions", function()

--- a/titan-compiler/ast.lua
+++ b/titan-compiler/ast.lua
@@ -38,7 +38,7 @@ declare_type("Stat", {
     Assign = {"loc", "var", "exp"},
     Decl   = {"loc", "decl", "exp"},
     Call   = {"loc", "callexp"},
-    Return = {"loc", "exp"},
+    Return = {"loc", "exps"},
 })
 
 declare_type("Then", {

--- a/titan-compiler/checker.lua
+++ b/titan-compiler/checker.lua
@@ -292,8 +292,9 @@ check_stat = function(stat, errors, rettypes)
     elseif tag == ast.Stat.Return then
         assert(#rettypes == 1)
         local rettype = rettypes[1]
-        check_exp(stat.exp, errors, rettype)
-        checkmatch("return statement", rettype, stat.exp._type, errors, stat.exp.loc)
+        local exp = stat.exps[1]
+        check_exp(exp, errors, rettype)
+        checkmatch("return statement", rettype, exp._type, errors, exp.loc)
         return true
 
     elseif tag == ast.Stat.If then

--- a/titan-compiler/checker.lua
+++ b/titan-compiler/checker.lua
@@ -13,7 +13,6 @@ local check_stat
 --local check_then
 local check_var
 local check_exp
---local check_args
 --local check_field
 
 -- Type-check a Titan module
@@ -113,7 +112,7 @@ check_type = function(typ, errors)
 
     elseif tag == ast.Type.Function then
         if #typ.rettypes >= 2 then
-            error("functions with 0 or 2+ return values are not yet implemented")
+            error("functions with 2+ return values are not yet implemented")
         end
         local ptypes = {}
         for _, ptype in ipairs(typ.argtypes) do
@@ -148,7 +147,7 @@ check_toplevel = function(tl_node, errors)
 
     elseif tag == ast.Toplevel.Func then
         if #tl_node.rettypes >= 2 then
-            error("functions with 0 or 2+ return values are not yet implemented")
+            error("functions with 2+ return values are not yet implemented")
         end
 
         local ptypes = {}
@@ -563,7 +562,7 @@ check_exp = function(exp, errors, typehint)
                         "left hand side of arithmetic expression is a %s instead of a number",
                         types.tostring(exp.lhs._type))
                 end
-                if not is_numeric_type(exp.lhs._type) then
+                if not is_numeric_type(exp.rhs._type) then
                     type_error(errors, exp.loc,
                         "right hand side of arithmetic expression is a %s instead of a number",
                         types.tostring(exp.rhs._type))
@@ -657,7 +656,7 @@ check_exp = function(exp, errors, typehint)
             if #ftype.rettypes >= 1 then
                 exp._type = ftype.rettypes[1]
             else
-                exp._type = types.T.Invalid()
+                exp._type = types.T.Void()
             end
         else
             type_error(errors, exp.loc,

--- a/titan-compiler/coder.lua
+++ b/titan-compiler/coder.lua
@@ -636,7 +636,9 @@ generate_stat = function(stat)
         })
 
     elseif tag == ast.Stat.Return then
-        local cstats, cvalue = generate_exp(stat.exp)
+        assert(#stat.exps == 1)
+        local exp = stat.exps[1]
+        local cstats, cvalue = generate_exp(exp)
         return util.render([[
             ${CSTATS}
             return ${CVALUE};

--- a/titan-compiler/coder.lua
+++ b/titan-compiler/coder.lua
@@ -348,7 +348,7 @@ generate_program = function(prog, modname)
                     set_ret = ""
                 elseif #tl_node._type.rettypes == 1 then
                     local ret_typ = tl_node._type.rettypes[1]
-                        ret_init = c_declaration(ctype(ret_typ), "ret") .. " ="
+                    ret_init = c_declaration(ctype(ret_typ), "ret") .. " ="
                     set_ret = util.render([[
                         ${SET_SLOT}
                         api_incr_top(L);
@@ -358,7 +358,6 @@ generate_program = function(prog, modname)
                 else
                     error("not implemented")
                 end
-
 
                 table.insert(function_definitions,
                     util.render([[
@@ -652,7 +651,7 @@ generate_stat = function(stat)
         local cstats, cvalue = generate_exp(stat.callexp)
 
         local ignore_result
-        if stat.callexp._type._tag == types.T.Invalid then
+        if stat.callexp._type._tag == types.T.Void then
             ignore_result = ""
         else
             ignore_result = "(void) " .. cvalue .. ";"
@@ -857,7 +856,7 @@ generate_exp = function(exp) -- TODO
                     FUN_NAME  = tl_node._titan_entry_point,
                     ARG_STATS = table.concat(arg_cstatss, "\n"),
                     ARGS      = table.concat(arg_cvalues, ", "),
-                    TMP_INIT = tmp_init,
+                    TMP_INIT  = tmp_init,
                 })
                 return cstats, tmp_var
 

--- a/titan-compiler/coder.lua
+++ b/titan-compiler/coder.lua
@@ -666,9 +666,16 @@ generate_stat = function(stat)
         })
 
     elseif tag == ast.Stat.Return then
-        assert(#stat.exps == 1)
-        local exp = stat.exps[1]
-        local cstats, cvalue = generate_exp(exp)
+        assert(#stat.exps <= 1)
+
+        local cstats, cvalue
+        if #stat.exps == 0 then
+            cstats = ""
+            cvalue = ""
+        else
+            cstats, cvalue = generate_exp(stat.exps[1])
+        end
+
         return util.render([[
             ${CSTATS}
             return ${CVALUE};

--- a/titan-compiler/parser.lua
+++ b/titan-compiler/parser.lua
@@ -289,7 +289,7 @@ local grammar = re.compile([[
 
     elseopt         <- (ELSE block)?                             -> opt
 
-    returnstat      <- (P  RETURN (exp? -> opt) SEMICOLON?)      -> StatReturn
+    returnstat      <- (P  RETURN {| exp? |} SEMICOLON?)         -> StatReturn
 
     op1             <- ( OR -> 'or' )
     op2             <- ( AND -> 'and' )

--- a/titan-compiler/parser.lua
+++ b/titan-compiler/parser.lua
@@ -45,11 +45,9 @@ function defs.tofalse()
     return false
 end
 
-function defs.rettypeopt(pos, x)
+function defs.rettypeopt(_pos, x)
     if not x then
-        -- When possible, we should change this default to the empty list
-        -- or infer the return type.
-        return { ast.Type.Nil(pos) }
+        return { }
     else
         return x
     end

--- a/titan-compiler/scope_analysis.lua
+++ b/titan-compiler/scope_analysis.lua
@@ -217,7 +217,9 @@ bind_names_stat = function(stat, st, errors)
         bind_names_exp(stat.callexp, st, errors)
 
     elseif tag == ast.Stat.Return then
-        bind_names_exp(stat.exp, st, errors)
+        for _, exp in ipairs(stat.exps) do
+            bind_names_exp(exp, st, errors)
+        end
 
     else
         error("impossible")

--- a/titan-compiler/types.lua
+++ b/titan-compiler/types.lua
@@ -8,6 +8,7 @@ end
 
 declare_type("T", {
     Invalid  = {},
+    Void     = {}, -- Special kind of "invalid", for functions with 0 returns
     Nil      = {},
     Boolean  = {},
     Integer  = {},
@@ -86,6 +87,7 @@ function types.tostring(t)
     elseif tag == types.T.Nil         then return "nil"
     elseif tag == types.T.Float       then return "float"
     elseif tag == types.T.Invalid     then return "invalid type"
+    elseif tag == types.T.Void        then return "void"
     elseif tag == types.T.Function then
         return "function" -- TODO implement
     elseif tag == types.T.Array then


### PR DESCRIPTION
I think functions that return nothing are better "void" functions than functions that return "nil".

This also changes the test for "control reaches end of non-void" function to require a "return nil" for functions that return nil, and only make the return statement be optional in functions that return 0 values.