### PR TITLE
Separate regular function calls from method calls

### DIFF
--- a/spec/parser_spec.lua
+++ b/spec/parser_spec.lua
@@ -397,7 +397,7 @@ describe("Titan parser", function()
                         var = { name = "x" },
                         exp = { value = 11 } },
                     { _tag = ast.Stat.Call,
-                        callexp = { _tag = ast.Exp.Call } } } },
+                        callexp = { _tag = ast.Exp.CallFunc } } } },
         })
     end)
 
@@ -540,44 +540,44 @@ describe("Titan parser", function()
                     lhs = { _tag = ast.Exp.Var, var = {
                         _tag = ast.Var.Bracket,
                         exp2 = { value = 2 },
-                        exp1 = { _tag = ast.Exp.Call,
-                            args = { _tag = ast.Args.Func },
-                            exp = { _tag = ast.Exp.Call,
-                                args = { _tag = ast.Args.Func },
+                        exp1 = { _tag = ast.Exp.CallFunc,
+                            args = { },
+                            exp = { _tag = ast.Exp.CallFunc,
+                                args = { },
                                 exp = { _tag = ast.Exp.Var,
                                     var = { _tag = ast.Var.Name, name = "x" }}}}}}}})
     end)
 
     it("can parse function calls without the optional parenthesis", function()
         assert_expression_ast([[ f() ]],
-            { _tag = ast.Exp.Call, args = {
-                _tag = ast.Args.Func, args = { } } })
+            { _tag = ast.Exp.CallFunc, args = { } })
 
         assert_expression_ast([[ f "qwe" ]],
-            { _tag = ast.Exp.Call, args = {
-                _tag = ast.Args.Func, args = {
-                    { _tag = ast.Exp.String, value = "qwe" } } } })
+            { _tag = ast.Exp.CallFunc, args = {
+                { _tag = ast.Exp.String, value = "qwe" } } })
 
         assert_expression_ast([[ f {} ]],
-            { _tag = ast.Exp.Call, args = {
-                _tag = ast.Args.Func, args = {
-                    { _tag = ast.Exp.Initlist } } } })
+            { _tag = ast.Exp.CallFunc, args = {
+                { _tag = ast.Exp.Initlist } } })
     end)
 
     it("can parse method calls without the optional parenthesis", function()
         assert_expression_ast([[ o:m () ]],
-            { _tag = ast.Exp.Call, args = {
-                _tag = ast.Args.Method, args = { } } })
+            { _tag = ast.Exp.CallMethod,
+                method = "m",
+                args = { } })
 
         assert_expression_ast([[ o:m "asd" ]],
-            { _tag = ast.Exp.Call, args = {
-                _tag = ast.Args.Method, args = {
-                    { _tag = ast.Exp.String, value = "asd" } } } })
+            { _tag = ast.Exp.CallMethod,
+                method = "m",
+                args = {
+                    { _tag = ast.Exp.String, value = "asd" } } })
 
         assert_expression_ast([[ o:m {} ]],
-            { _tag = ast.Exp.Call, args = {
-                _tag = ast.Args.Method, args = {
-                    { _tag = ast.Exp.Initlist } } } })
+            { _tag = ast.Exp.CallMethod,
+                method = "m",
+                args = {
+                    { _tag = ast.Exp.Initlist } } })
     end)
 
     it("only allows call expressions as statements", function()
@@ -610,12 +610,12 @@ describe("Titan parser", function()
                   var = { _tag = ast.Var.Name, name = "foo" }
                 },
                 name = "bar" } },
-            { callexp = { args = { args = { { var = {
+            { callexp = { args = { { var = {
                 _tag = ast.Var.Dot,
                 exp = { _tag = ast.Exp.Var,
                   var = { _tag = ast.Var.Name, name = "foo" }
                 },
-              name = "bar" } } } } } },
+              name = "bar" } } } } },
             { callexp = {
                 exp = { var = {
                     _tag = ast.Var.Dot,
@@ -687,20 +687,20 @@ describe("Titan parser", function()
                 { name = "next", exp = { _tag = ast.Exp.Nil } } }})
 
         assert_expression_ast([[ Point.new(1.1, 2.2) ]],
-            { _tag = ast.Exp.Call,
-                args = { args = {
+            { _tag = ast.Exp.CallFunc,
+                args = {
                   { value = 1.1 },
-                  { value = 2.2 } } },
+                  { value = 2.2 } },
                 exp = { var = {
                     _tag = ast.Var.Dot,
                     exp = { var = { name = "Point" } },
                     name = "new" } } })
 
         assert_expression_ast([[ List.new({}, nil) ]],
-            { _tag = ast.Exp.Call,
-                args = { args = {
+            { _tag = ast.Exp.CallFunc,
+                args = {
                   { _tag = ast.Exp.Initlist },
-                  { _tag = ast.Exp.Nil } } },
+                  { _tag = ast.Exp.Nil } },
                 exp = { var = {
                     _tag = ast.Var.Dot,
                     exp = { var = { name = "List" } },

--- a/titan-compiler/ast.lua
+++ b/titan-compiler/ast.lua
@@ -52,23 +52,19 @@ declare_type("Var", {
 })
 
 declare_type("Exp", {
-    Nil      = {"loc"},
-    Bool     = {"loc", "value"},
-    Integer  = {"loc", "value"},
-    Float    = {"loc", "value"},
-    String   = {"loc", "value"},
-    Initlist = {"loc", "fields"},
-    Call     = {"loc", "exp", "args"},
-    Var      = {"loc", "var"},
-    Unop     = {"loc", "op", "exp"},
-    Concat   = {"loc", "exps"},
-    Binop    = {"loc", "lhs", "op", "rhs"},
-    Cast     = {"loc", "exp", "target"}
-})
-
-declare_type("Args", {
-    Func   = {"loc", "args"},
-    Method = {"loc", "method", "args"},
+    Nil        = {"loc"},
+    Bool       = {"loc", "value"},
+    Integer    = {"loc", "value"},
+    Float      = {"loc", "value"},
+    String     = {"loc", "value"},
+    Initlist   = {"loc", "fields"},
+    CallFunc   = {"loc", "exp", "args"},
+    CallMethod = {"loc", "exp", "method", "args"},
+    Var        = {"loc", "var"},
+    Unop       = {"loc", "op", "exp"},
+    Concat     = {"loc", "exps"},
+    Binop      = {"loc", "lhs", "op", "rhs"},
+    Cast       = {"loc", "exp", "target"}
 })
 
 declare_type("Field", {

--- a/titan-compiler/checker.lua
+++ b/titan-compiler/checker.lua
@@ -617,7 +617,7 @@ check_exp = function(exp, errors, typehint)
             error("impossible")
         end
 
-    elseif tag == ast.Exp.Call then
+    elseif tag == ast.Exp.CallFunc then
         assert(exp.exp._tag == ast.Exp.Var, "function calls are first-order only!")
         local var = exp.exp.var
         check_var(var, errors)
@@ -626,7 +626,7 @@ check_exp = function(exp, errors, typehint)
         if var._type._tag == types.T.Function then
             local ftype = var._type
             local nparams = #ftype.params
-            local args = exp.args.args
+            local args = exp.args
             local nargs = #args
             local arity = math.max(nparams, nargs)
             for i = 1, arity do
@@ -664,6 +664,9 @@ check_exp = function(exp, errors, typehint)
                 fname, types.tostring(var._type))
             exp._type = types.T.Invalid()
         end
+
+    elseif tag == ast.Exp.CallMethod then
+        error("not implemented")
 
     elseif tag == ast.Exp.Cast then
         local target = check_type(exp.target, errors)

--- a/titan-compiler/parser.lua
+++ b/titan-compiler/parser.lua
@@ -141,13 +141,13 @@ end
 
 function defs.suffix_funccall(pos, args)
     return function(exp)
-        return ast.Exp.Call(pos, exp, ast.Args.Func(pos, args))
+        return ast.Exp.CallFunc(pos, exp,  args)
     end
 end
 
 function defs.suffix_methodcall(pos, name, args)
     return function(exp)
-        return ast.Exp.Call(pos, exp, ast.Args.Method(pos, name, args))
+        return ast.Exp.CallMethod(pos, exp, name, args)
     end
 end
 
@@ -184,7 +184,8 @@ function defs.exp_is_var(_, pos, exp)
 end
 
 function defs.exp_is_call(_, pos, exp)
-    if exp._tag == ast.Exp.Call then
+    if exp._tag == ast.Exp.CallFunc or
+       exp._tag == ast.Exp.CallMethod then
         return pos, exp
     else
         return false

--- a/titan-compiler/scope_analysis.lua
+++ b/titan-compiler/scope_analysis.lua
@@ -13,7 +13,6 @@ local bind_names_stat
 local bind_names_then
 local bind_names_var
 local bind_names_exp
-local bind_names_args
 local bind_names_field
 
 -- Implement the lexical scoping for a Titan module.
@@ -290,9 +289,17 @@ bind_names_exp = function(exp, st, errors)
             bind_names_field(field, st, errors)
         end
 
-    elseif tag == ast.Exp.Call then
+    elseif tag == ast.Exp.CallFunc then
         bind_names_exp(exp.exp, st, errors)
-        bind_names_args(exp.args, st, errors)
+        for _, arg_exp in ipairs(exp.args) do
+            bind_names_exp(arg_exp, st, errors)
+        end
+
+    elseif tag == ast.Exp.CallMethod then
+        bind_names_exp(exp.exp, st, errors)
+        for _, arg_exp in ipairs(exp.args) do
+            bind_names_exp(arg_exp, st, errors)
+        end
 
     elseif tag == ast.Exp.Var then
         bind_names_var(exp.var, st, errors)
@@ -312,23 +319,6 @@ bind_names_exp = function(exp, st, errors)
     elseif tag == ast.Exp.Cast then
         bind_names_exp(exp.exp, st, errors)
         bind_names_type(exp.target, st, errors)
-
-    else
-        error("impossible")
-    end
-end
-
-bind_names_args = function(args, st, errors)
-    local tag = args._tag
-    if     tag == ast.Args.Func then
-        for _, exp in ipairs(args.args) do
-            bind_names_exp(exp, st, errors)
-        end
-
-    elseif tag == ast.Args.Method then
-        for _, exp in ipairs(args.args) do
-            bind_names_exp(exp, st, errors)
-        end
 
     else
         error("impossible")


### PR DESCRIPTION
The "Args" datatype was convenient for the parser but got in the way
everywhere else.