### PR TITLE
Some fixes to `titanc` and examples

### DIFF
--- a/examples/test_fill_table.lua
+++ b/examples/test_fill_table.lua
@@ -1,4 +1,4 @@
-local mod = require "artisanal"
+local mod = require "examples.artisanal"
 
 local f = mod.filltable
 

--- a/examples/test_quicksort.lua
+++ b/examples/test_quicksort.lua
@@ -1,6 +1,6 @@
 local N    = arg[1] and tonumber(arg[1]) or 5000
 
-local sort = require("artisanal").qsort
+local sort = require("examples.artisanal").qsort
 
 local function make_input(N)
     local xs = {}

--- a/examples/test_selection_sort.lua
+++ b/examples/test_selection_sort.lua
@@ -1,6 +1,6 @@
 local N    = arg[1] and tonumber(arg[1]) or 5000
 
-local sort = require("artisanal").sort
+local sort = require("examples.artisanal").sort
 
 local function make_input(N)
     local xs = {}

--- a/examples/test_sieve.lua
+++ b/examples/test_sieve.lua
@@ -1,6 +1,6 @@
 local N    = arg[1] and tonumber(arg[1]) or 1000000
 
-local f = require("artisanal").sieve
+local f = require("examples.artisanal").sieve
 
 local ps = f(N)
 print(#ps)

--- a/examples/test_split_flatten.lua
+++ b/examples/test_split_flatten.lua
@@ -1,4 +1,4 @@
-local titan = require "artisanal"
+local titan = require "examples.utils"
 
 local t = {}
 

--- a/examples/test_sum_1_N.lua
+++ b/examples/test_sum_1_N.lua
@@ -1,6 +1,6 @@
 local N    = arg[1] and tonumber(arg[1]) or 500000000
 
-local f = require("artisanal").sum
+local f = require("examples.artisanal").sum
 
 print("N="..N)
 local r = f(N)

--- a/titan-compiler/driver.lua
+++ b/titan-compiler/driver.lua
@@ -104,17 +104,17 @@ end
 
 function driver.compile_module(modname, mod)
     if mod.compiled then return true end
-    local ok, err = driver.compile(modname, mod.ast)
+    local ok, err = driver.compile(modname, mod.ast, mod.filename)
     if not ok then return nil, err end
     mod.compiled = true
     return true
 end
 
-function driver.compile(modname, ast)
+function driver.compile(modname, ast, sourcef)
     local code = coder.generate(modname, ast)
     code = pretty.reindent_c(code)
-    local filename = modname .. ".c"
-    local soname = modname .. ".so"
+    local filename = sourcef:gsub("[.]titan$", "") .. ".c"
+    local soname = sourcef:gsub("[.]titan$", "") .. ".so"
     os.remove(filename)
     os.remove(soname)
     local ok, err = util.set_file_contents(filename, code)

--- a/titan-compiler/driver.lua
+++ b/titan-compiler/driver.lua
@@ -111,6 +111,7 @@ function driver.compile_module(modname, mod)
 end
 
 function driver.compile(modname, ast, sourcef)
+    sourcef = sourcef or modname:gsub("[.]", "/") .. ".titan"
     local code = coder.generate(modname, ast)
     code = pretty.reindent_c(code)
     local filename = sourcef:gsub("[.]titan$", "") .. ".c"


### PR DESCRIPTION
The `driver.compile` function was not taking into account dots in the module name, so `titanc` was generating files with wrong names. Also renamed `titanc` to `titan`, to reflect the change in the help text for it.