### PR TITLE
Make the generated code less cluttered

### DIFF
--- a/spec/coder_spec.lua
+++ b/spec/coder_spec.lua
@@ -78,6 +78,21 @@ describe("Titan coder", function()
         ]])
     end)
 
+    it("Verify the argument's tag (float/integer vs number)", function()
+        run_coder([[
+            function f(x: float): float
+                return x
+            end
+        ]], [[
+            local ok, err = pcall(test.f, 10)
+            assert(string.find(err,
+                "wrong type for argument x at line 1, " ..
+                "expected float but found integer",
+                nil, true))
+        ]])
+    end)
+
+
     describe("Expressions:", function()
 
         it("Constants", function()

--- a/spec/coder_spec.lua
+++ b/spec/coder_spec.lua
@@ -90,8 +90,19 @@ describe("Titan coder", function()
                 "expected float but found integer",
                 nil, true))
         ]])
-    end)
 
+        run_coder([[
+            function f(x: integer): integer
+                return x
+            end
+        ]], [[
+            local ok, err = pcall(test.f, 3.14)
+            assert(string.find(err,
+                "wrong type for argument x at line 1, " ..
+                "expected integer but found float",
+                nil, true))
+        ]])
+    end)
 
     describe("Expressions:", function()
 

--- a/spec/coder_spec.lua
+++ b/spec/coder_spec.lua
@@ -796,11 +796,14 @@ describe("Titan coder", function()
             ]])
         end)
 
-        it("can set wrongly typed arrays in set", function()
+        it("checks type tags in set", function()
             run_coder(array_get_set, [[
                 local arr = {10, 20, "hello"}
-                test.set(arr, 3, 123)
-                assert(123 == arr[3])
+
+                local ok, err = pcall(test.set, arr, 3, 20)
+                assert(not ok)
+                assert(
+                    string.find(err, "wrong type for array element", nil, true))
             ]])
         end)
 

--- a/titan-compiler/c_compiler.lua
+++ b/titan-compiler/c_compiler.lua
@@ -5,7 +5,7 @@ local c_compiler = {}
 
 c_compiler.LUA_SOURCE_PATH = "./lua/src"
 c_compiler.CFLAGS_BASE = "--std=c99 -g "
-c_compiler.CFLAGS_WARN = "-Wall -Wno-unused-function -Wno-parenthesis-equality"
+c_compiler.CFLAGS_WARN = "-Wall -Wno-unused-function -Wno-parentheses-equality"
 c_compiler.CFLAGS_OPT = "-O2"
 c_compiler.CC = "cc"
 

--- a/titan-compiler/c_compiler.lua
+++ b/titan-compiler/c_compiler.lua
@@ -4,7 +4,7 @@ local util = require "titan-compiler.util"
 local c_compiler = {}
 
 c_compiler.LUA_SOURCE_PATH = "./lua/src"
-c_compiler.CFLAGS_BASE = "--std=c99 -Wall -g"
+c_compiler.CFLAGS_BASE = "--std=c99 -Wall -g -Wno-unused-function"
 c_compiler.CFLAGS_OPT = "-O2"
 c_compiler.CC = "cc"
 

--- a/titan-compiler/c_compiler.lua
+++ b/titan-compiler/c_compiler.lua
@@ -4,7 +4,8 @@ local util = require "titan-compiler.util"
 local c_compiler = {}
 
 c_compiler.LUA_SOURCE_PATH = "./lua/src"
-c_compiler.CFLAGS_BASE = "--std=c99 -Wall -g -Wno-unused-function"
+c_compiler.CFLAGS_BASE = "--std=c99 -g "
+c_compiler.CFLAGS_WARN = "-Wall -Wno-unused-function -Wno-parenthesis-equality"
 c_compiler.CFLAGS_OPT = "-O2"
 c_compiler.CC = "cc"
 
@@ -53,6 +54,7 @@ function c_compiler.compile_c_to_so(c_filename, so_filename)
     local args = {
         c_compiler.CC,
         c_compiler.CFLAGS_BASE,
+        c_compiler.CFLAGS_WARN,
         c_compiler.CFLAGS_OPT,
         c_compiler.CFLAGS_SHARED,
         "-I", c_compiler.LUA_SOURCE_PATH,

--- a/titan-compiler/coder.lua
+++ b/titan-compiler/coder.lua
@@ -54,11 +54,6 @@ local whole_file_template = [[
 
 #include "math.h"
 
-/* Ignore noisy warnings caused by clang's -Wall */
-#ifdef __clang__
-#pragma clang diagnostic ignored "-Wparentheses-equality"
-#endif
-
 static const char * titan_tag_name(int raw_tag)
 {
     if (raw_tag == LUA_TNUMINT) {

--- a/titan-compiler/coder.lua
+++ b/titan-compiler/coder.lua
@@ -1057,10 +1057,10 @@ generate_stat = function(stat, ctx)
         ctx:end_scope()
         return util.render([[
             ${START_STAT}
-            ${START_DECL} = ${START_VALUE};
             ${FINISH_STAT}
-            ${FINISH_DECL} = ${FINISH_VALUE};
             ${INC_STAT}
+            ${START_DECL} = ${START_VALUE};
+            ${FINISH_DECL} = ${FINISH_VALUE};
             ${INC_DECL} = ${INC_VALUE};
             while (${LOOP_COND}) {
                 ${LOOPVAR_DECL} = ${START};

--- a/titan-compiler/coder.lua
+++ b/titan-compiler/coder.lua
@@ -1645,7 +1645,7 @@ generate_exp = function(exp, ctx)
         -- parameters
         local function binop(op)
             local cstats = lhs_cstats..rhs_cstats
-            local cvalue = util.render("((${LHS})${OP}(${RHS}))", {
+            local cvalue = util.render("(${LHS} ${OP} ${RHS})", {
                 OP=op, LHS=lhs_cvalue, RHS=rhs_cvalue })
             return cstats, cvalue
         end

--- a/titan-compiler/coder.lua
+++ b/titan-compiler/coder.lua
@@ -1104,11 +1104,7 @@ generate_stat = function(stat, ctx)
                 stat.exp._type, var_lvalue.slot_address, exp_cvalue,
                 var_lvalue.parent_pointer)
             assign_stat = util.render([[
-                if (!${CHECK_TAG}) {
-                    titan_runtime_array_type_error(
-                        L, ${LINE}, ${EXPECTED_TAG}, ${SLOT}
-                    );
-                }
+                if (!${CHECK_TAG}) { titan_runtime_array_type_error( L, ${LINE}, ${EXPECTED_TAG}, ${SLOT} ); }
                 ${ASSIGN_SLOT}
             ]], {
                 SLOT = var_lvalue.slot_address,
@@ -1231,9 +1227,7 @@ generate_var = function(var, ctx)
             ${T_CSTATS}
             ${K_CSTATS}
             ${UI_DECL} = ((lua_Unsigned)${K_CVALUE}) - 1;
-            if (${UI_NAME} >= ${T_CVALUE}->sizearray) {
-                titan_runtime_array_bounds_error(L, ${LINE});
-            }
+            if (${UI_NAME} >= ${T_CVALUE}->sizearray) { titan_runtime_array_bounds_error(L, ${LINE}); }
             ${SLOT_DECL} = &${T_CVALUE}->array[${UI_NAME}];
         ]], {
             T_CSTATS = t_cstats,
@@ -1567,11 +1561,7 @@ generate_exp = function(exp, ctx)
             local slot = lvalue.slot_address
             local cstats = util.render([[
                 ${EXP_STATS}
-                if (!${CHECK_TAG}) {
-                    titan_runtime_array_type_error(
-                        L, ${LINE}, ${EXPECTED_TAG}, ${SLOT}
-                    );
-                }
+                if (!${CHECK_TAG}) { titan_runtime_array_type_error( L, ${LINE}, ${EXPECTED_TAG}, ${SLOT} ); }
                 ${VAR_DECL} = ${GET_SLOT};
             ]], {
                 EXP_STATS = exp_cstats,

--- a/titan-compiler/coder.lua
+++ b/titan-compiler/coder.lua
@@ -390,7 +390,6 @@ local function titan_type_tag(typ)
     else error("impossible")
     end
     return util.render(tmpl, {SLOT = slot})
-
 end
 
 -- Specialized version of luaH_barrierback. To be called when setting v as an
@@ -1099,7 +1098,7 @@ generate_stat = function(stat, ctx)
                 stat.exp._type, var_lvalue.slot_address, exp_cvalue,
                 var_lvalue.parent_pointer)
             assign_stat = util.render([[
-                if (!${CHECK_TAG}) { titan_runtime_array_type_error( L, ${LINE}, ${EXPECTED_TAG}, ${SLOT} ); }
+                if (!${CHECK_TAG}) { titan_runtime_array_type_error(L, ${LINE}, ${EXPECTED_TAG}, ${SLOT}); }
                 ${ASSIGN_SLOT}
             ]], {
                 SLOT = var_lvalue.slot_address,
@@ -1572,7 +1571,6 @@ generate_exp = function(exp, ctx)
         else
             error("impossible")
         end
-        return cstats, cvalue
 
     elseif tag == ast.Exp.Unop then
         local cstats, cvalue = generate_exp(exp.exp, ctx)

--- a/titan-compiler/coder.lua
+++ b/titan-compiler/coder.lua
@@ -612,9 +612,7 @@ local function generate_lua_entry_point(tl_node)
     local nargs = ctx:new_cvar("int", "nargs")
     local check_nargs = util.render([[
         ${NARGS_DECL} = cast_int(L->top - (${BASE} + 1));
-        if (${NARGS} != ${EXPECTED}) {
-            titan_runtime_arity_error(L, ${EXPECTED}, ${NARGS});
-        }
+        if (${NARGS} != ${EXPECTED}) { titan_runtime_arity_error(L, ${EXPECTED}, ${NARGS}); }
     ]], {
         BASE = base.name,
         NARGS = nargs.name,
@@ -636,11 +634,7 @@ local function generate_lua_entry_point(tl_node)
         local slot = ctx:new_cvar("TValue*")
         table.insert(check_types, util.render([[
             ${SLOT_DECL} = ${SLOT_ADDRESS};
-            if (!${CHECK_TAG}) {
-                titan_runtime_argument_type_error(
-                    L, ${PARAM_NAME}, ${LINE}, ${EXPECTED_TAG}, ${SLOT_NAME}
-                );
-            }
+            if (!${CHECK_TAG}) { titan_runtime_argument_type_error(L, ${PARAM_NAME}, ${LINE}, ${EXPECTED_TAG}, ${SLOT_NAME}); }
         ]], {
             SLOT_NAME = slot.name,
             SLOT_DECL = c_declaration(slot),
@@ -1502,11 +1496,7 @@ generate_exp = function(exp, ctx)
                 retval = ret.name
                 table.insert(body, util.render([[
                     ${SLOT_DECL} = s2v(L->top-1);
-                    if (!${CHECK_TAG}) {
-                        titan_runtime_function_return_error(
-                            L, ${LINE}, ${EXPECTED_TAG}, ${SLOT}
-                        );
-                    }
+                    if (!${CHECK_TAG}) { titan_runtime_function_return_error(L, ${LINE}, ${EXPECTED_TAG}, ${SLOT}); }
                     ${RET_DECL} = ${GET_SLOT};
                     L->top--;
                 ]], {
@@ -1555,7 +1545,7 @@ generate_exp = function(exp, ctx)
             local slot = lvalue.slot_address
             local cstats = util.render([[
                 ${EXP_STATS}
-                if (!${CHECK_TAG}) { titan_runtime_array_type_error( L, ${LINE}, ${EXPECTED_TAG}, ${SLOT} ); }
+                if (!${CHECK_TAG}) { titan_runtime_array_type_error(L, ${LINE}, ${EXPECTED_TAG}, ${SLOT}); }
                 ${VAR_DECL} = ${GET_SLOT};
             ]], {
                 EXP_STATS = exp_cstats,


### PR DESCRIPTION
Some miscelaneous changes aimed at making the generated code more compact and easier to read.

The biggest change is that the error paths are encapsulated inside functions now. Another notable change is that runtime error messages now talk only about Lua tags instead of Titan types (it is clever enough to show integer/float instead of number though).

One thing that probably needs to be improved is hot to handle the warning-supression flags. Right now they are split between the CFLAGS in c_compiler.lua and \#pragma declarations in the generated C code. Ideally we should only do it one way but which way is better? Do those \#pragma declarations also apply to non-clang compilers?