### PR TITLE
Make generate_exp always return a single token

### DIFF
--- a/runtime/tcore.c
+++ b/runtime/tcore.c
@@ -119,3 +119,10 @@ void titan_runtime_divide_by_zero_error(
     luaL_error(L, "attempt to divide by zero");
     TITAN_UNREACHABLE;
 }
+
+void titan_runtime_mod_by_zero_error(
+    lua_State *L
+){
+    luaL_error(L, "attempt to perform 'n%%0'");
+    TITAN_UNREACHABLE;
+}

--- a/runtime/tcore.c
+++ b/runtime/tcore.c
@@ -112,3 +112,10 @@ void titan_runtime_function_return_error(
     );
     TITAN_UNREACHABLE;
 }
+
+void titan_runtime_divide_by_zero_error(
+    lua_State *L
+){
+    luaL_error(L, "attempt to divide by zero");
+    TITAN_UNREACHABLE;
+}

--- a/runtime/tcore.c
+++ b/runtime/tcore.c
@@ -114,15 +114,17 @@ void titan_runtime_function_return_error(
 }
 
 void titan_runtime_divide_by_zero_error(
-    lua_State *L
+    lua_State *L,
+    int line
 ){
-    luaL_error(L, "attempt to divide by zero");
+    luaL_error(L, "attempt to divide by zero at line %d", line);
     TITAN_UNREACHABLE;
 }
 
 void titan_runtime_mod_by_zero_error(
-    lua_State *L
+    lua_State *L,
+    int line
 ){
-    luaL_error(L, "attempt to perform 'n%%0'");
+    luaL_error(L, "attempt to perform 'n%%0' at line %d", line);
     TITAN_UNREACHABLE;
 }

--- a/runtime/tcore.h
+++ b/runtime/tcore.h
@@ -36,4 +36,8 @@ void titan_runtime_divide_by_zero_error(
     lua_State *L)
     TITAN_NORETURN;
 
+void titan_runtime_mod_by_zero_error(
+    lua_State *L)
+    TITAN_NORETURN;
+
 #endif

--- a/runtime/tcore.h
+++ b/runtime/tcore.h
@@ -33,11 +33,11 @@ void titan_runtime_function_return_error(
     TITAN_NORETURN;
 
 void titan_runtime_divide_by_zero_error(
-    lua_State *L)
+    lua_State *L, int line)
     TITAN_NORETURN;
 
 void titan_runtime_mod_by_zero_error(
-    lua_State *L)
+    lua_State *L, int line)
     TITAN_NORETURN;
 
 #endif

--- a/runtime/tcore.h
+++ b/runtime/tcore.h
@@ -32,4 +32,8 @@ void titan_runtime_function_return_error(
     lua_State *L, int line, int expected_tag, TValue *slot)
     TITAN_NORETURN;
 
+void titan_runtime_divide_by_zero_error(
+    lua_State *L)
+    TITAN_NORETURN;
+
 #endif

--- a/spec/coder_spec.lua
+++ b/spec/coder_spec.lua
@@ -542,6 +542,29 @@ describe("Titan coder", function()
         end)
     end)
 
+    describe("Two-s compliment integer arithmetic", function()
+        it("unary (-)", function()
+            run_coder([[
+                function f(x:integer): integer
+                    return -x
+                end
+            ]], [[
+                assert(math.mininteger == test.f(math.mininteger))
+            ]])
+        end)
+
+        it("unary (+)", function()
+            run_coder([[
+                function f(x:integer, y:integer): integer
+                    return x + y
+                end
+            ]], [[
+                assert(math.mininteger == test.f(math.maxinteger, 1))
+                assert(math.maxinteger == test.f(math.mininteger, -1))
+            ]])
+        end)
+    end)
+
     describe("Statements", function()
 
         it("Block, Assign, Decl", function()

--- a/spec/coder_spec.lua
+++ b/spec/coder_spec.lua
@@ -577,6 +577,20 @@ describe("Titan coder", function()
                 assert(math.mininteger == test.f(math.mininteger, -1))
             ]])
         end)
+
+        it("(%)", function()
+            run_coder([[
+                function f(x:integer, y:integer): integer
+                    return x % y
+                end
+            ]], [[
+                assert( 1 == test.f( 10,  3))
+                assert(-2 == test.f( 10, -3))
+                assert( 2 == test.f(-10,  3))
+                assert(-1 == test.f(-10, -3))
+                assert(0 == test.f(math.mininteger, -1))
+            ]])
+        end)
     end)
 
     describe("Statements", function()

--- a/spec/coder_spec.lua
+++ b/spec/coder_spec.lua
@@ -538,7 +538,6 @@ describe("Titan coder", function()
                 assert((false or true ) == test.bool_or(false, true))
                 assert((false or false) == test.bool_or(false, false))
             ]])
-
         end)
     end)
 

--- a/spec/coder_spec.lua
+++ b/spec/coder_spec.lua
@@ -563,6 +563,20 @@ describe("Titan coder", function()
                 assert(math.maxinteger == test.f(math.mininteger, -1))
             ]])
         end)
+
+        it("(//)", function()
+            run_coder([[
+                function f(x:integer, y:integer): integer
+                    return x // y
+                end
+            ]], [[
+                assert( 3 == test.f( 10,  3))
+                assert(-4 == test.f( 10, -3))
+                assert(-4 == test.f(-10,  3))
+                assert( 3 == test.f(-10, -3))
+                assert(math.mininteger == test.f(math.mininteger, -1))
+            ]])
+        end)
     end)
 
     describe("Statements", function()

--- a/titan-compiler/coder.lua
+++ b/titan-compiler/coder.lua
@@ -865,7 +865,7 @@ generate_stat = function(stat, ctx)
         return util.render([[
             for(;;) {
                 ${COND_STATS}
-                if (!(${COND})) break;
+                if (!${COND}) break;
                 ${BLOCK}
             }
         ]], {

--- a/titan-compiler/coder.lua
+++ b/titan-compiler/coder.lua
@@ -1710,12 +1710,8 @@ generate_exp = function(exp, ctx)
         error("not implemented yet")
 
     elseif tag == ast.Exp.Binop then
-        local lhs_cstats, lhs_cvalue = generate_exp(exp.lhs, ctx)
-        local rhs_cstats, rhs_cvalue = generate_exp(exp.rhs, ctx)
-
         local ltyp = exp.lhs._type._tag
         local rtyp = exp.rhs._type._tag
-
         local op = exp.op
         if     op == "+" then
             if     ltyp == types.T.Integer and rtyp == types.T.Integer then

--- a/titan-compiler/coder.lua
+++ b/titan-compiler/coder.lua
@@ -1321,7 +1321,7 @@ local function generate_binop_idiv_int(exp, ctx)
         ${Q_DECL};
         if (l_castS2U(${N}) + 1u <= 1u) {
             if (${N} == 0){
-                titan_runtime_divide_by_zero_error(L);
+                titan_runtime_divide_by_zero_error(L, ${LINE});
             } else {
                 ${Q} = intop(-, 0, ${M});
             }
@@ -1338,6 +1338,7 @@ local function generate_binop_idiv_int(exp, ctx)
         N_STATS = n_stats,
         Q = q.name,
         Q_DECL = c_declaration(q),
+        LINE = c_integer(exp.loc.line),
     })
     return cstats, q.name
 end
@@ -1354,7 +1355,7 @@ local function generate_binop_mod_int(exp, ctx)
         ${R_DECL};
         if (l_castS2U(${N}) + 1u <= 1u) {
             if (${N} == 0){
-                titan_runtime_mod_by_zero_error(L);
+                titan_runtime_mod_by_zero_error(L, ${LINE});
             } else {
                 ${R} = 0;
             }
@@ -1371,6 +1372,7 @@ local function generate_binop_mod_int(exp, ctx)
         N_STATS = n_stats,
         R = r.name,
         R_DECL = c_declaration(r),
+        LINE = c_integer(exp.loc.line),
     })
     return cstats, r.name
 end


### PR DESCRIPTION
That is, a variable name or constant literal.

Instead of compiling `(a + b) + c`  to `(a + b) + c)` the coder will now output something like

    tmp1 = a + b
    tmp2 = tmp1 + c

This should make the order of evaluation wholly unambiguous and ensure that the output of generate_exp can be safely passed to macros or macro-like things (like our version of luaV_div and so on).