### PR TITLE
Make Titan bitshift operators behave the same as Lua

### DIFF
--- a/runtime/tcore.h
+++ b/runtime/tcore.h
@@ -9,6 +9,8 @@
 #define TITAN_LIKELY(x)   __builtin_expect(!!(x), 1)
 #define TITAN_UNLIKELY(x) __builtin_expect(!!(x), 0)
 
+#define TITAN_LUAINTEGER_NBITS  cast_int(sizeof(lua_Integer) * CHAR_BIT)
+
 const char *titan_tag_name(int raw_tag);
 
 void titan_runtime_arity_error(

--- a/spec/coder_spec.lua
+++ b/spec/coder_spec.lua
@@ -541,7 +541,7 @@ describe("Titan coder", function()
         end)
     end)
 
-    describe("Two-s compliment integer arithmetic", function()
+    describe("Lua vs C operator semantics", function()
         it("unary (-)", function()
             run_coder([[
                 function f(x:integer): integer
@@ -569,10 +569,10 @@ describe("Titan coder", function()
                     return x // y
                 end
             ]], [[
-                assert( 3 == test.f( 10,  3))
-                assert(-4 == test.f( 10, -3))
-                assert(-4 == test.f(-10,  3))
-                assert( 3 == test.f(-10, -3))
+                assert( 10 //  3 == test.f( 10,  3))
+                assert( 10 // -3 == test.f( 10, -3))
+                assert(-10 //  3 == test.f(-10,  3))
+                assert(-10 // -3 == test.f(-10, -3))
                 assert(math.mininteger == test.f(math.mininteger, -1))
             ]])
         end)
@@ -583,11 +583,26 @@ describe("Titan coder", function()
                     return x % y
                 end
             ]], [[
-                assert( 1 == test.f( 10,  3))
-                assert(-2 == test.f( 10, -3))
-                assert( 2 == test.f(-10,  3))
-                assert(-1 == test.f(-10, -3))
+                assert( 10 %  3 == test.f( 10,  3))
+                assert( 10 % -3 == test.f( 10, -3))
+                assert(-10 %  3 == test.f(-10,  3))
+                assert(-10 % -3 == test.f(-10, -3))
                 assert(0 == test.f(math.mininteger, -1))
+            ]])
+        end)
+
+        it("(>>)", function()
+            run_coder([[
+                function f(x:integer, y:integer): integer
+                    return x >> y
+                end
+            ]], [[
+                assert(0xdead >>  1 == test.f(0xdead,  1))
+                assert(0xdead >> -1 == test.f(0xdead, -1))
+                assert(0 == test.f(0xdead,  100))
+                assert(0 == test.f(0xdead, -100))
+                assert(0 == test.f(0xdead, math.maxinteger))
+                assert(0 == test.f(0xdead, math.mininteger))
             ]])
         end)
     end)


### PR DESCRIPTION
In Lua, shifting by negative numbers shifts in the opposite direction and
shifting by an amount greater than or equal to the width of the integer type
results in 0.

Previously we were compiling titan bitshifts directly into C bitshifts, which
would run into undefined behavior in those cases.