### PR TITLE
Stop disabling clang's -Wparentheses-equality

### DIFF
--- a/titan-compiler/c_compiler.lua
+++ b/titan-compiler/c_compiler.lua
@@ -5,7 +5,7 @@ local c_compiler = {}
 
 c_compiler.CPPFLAGS = "-I./lua/src -I./runtime"
 c_compiler.CFLAGS_BASE = "--std=c99 -g -fPIC"
-c_compiler.CFLAGS_WARN = "-Wall -Wno-parentheses-equality"
+c_compiler.CFLAGS_WARN = "-Wall"
 c_compiler.CFLAGS_OPT = "-O2"
 c_compiler.CC = "cc"
 


### PR DESCRIPTION
Oops! I forgot to include this in PR #212...

We don't need this flag anymore and getting rid of it cleans up the code a bit. That
flag was the only thing we had that behaved differently on gcc and clang.