### PR TITLE
Add syntastic config to help with editing generated C files with vim

### DIFF
--- a/.syntastic_c_config
+++ b/.syntastic_c_config
@@ -1,0 +1,2 @@
+-I./lua/src/
+-I./runtime


### PR DESCRIPTION
I use the syntastic vim plugin to display syntax errors in the files I
edit and it would complain about not being able to find the ".h" files
that we include.