### PR TITLE
Add basic I/O output support

### DIFF
--- a/benchmarks/queen/lua.lua
+++ b/benchmarks/queen/lua.lua
@@ -1,0 +1,53 @@
+-- check whether position (n,c) is free from attacks
+local function isplaceok (a, n, c)
+  for i = 1, n - 1 do   -- for each queen already placed
+    local d = a[i]
+    if (d == c) or                -- same column?
+       (d - i == c - n) or        -- same diagonal?
+       (d + i == c + n) then      -- same diagonal?
+      return false            -- place can be attacked
+    end
+  end
+  return true    -- no attacks; place is OK
+end
+
+
+-- print a board
+local function printsolution (N, a)
+  for i = 1, N do
+    for j = 1, N do
+      if a[i] == j then
+        io.write("X")
+      else
+        io.write("-")
+      end
+      io.write(" ")
+    end
+    io.write("\n")
+  end
+  io.write("\n")
+end
+
+
+-- add to board 'a' all queens from 'n' to 'N'
+local function addqueen (N, a, n)
+  if n > N then    -- all queens have been placed?
+    printsolution(N, a)
+  else  -- try to place n-th queen
+    for c = 1, N do
+      if isplaceok(a, n, c) then
+        a[n] = c    -- place n-th queen at column 'c'
+        addqueen(N, a, n + 1)
+      end
+    end
+  end
+end
+
+-- run the program
+local function nqueens(N)
+    addqueen(N, {}, 1)
+end
+
+return {
+    nqueens = nqueens,
+}

--- a/benchmarks/queen/main.lua
+++ b/benchmarks/queen/main.lua
@@ -1,0 +1,2 @@
+local nqueens = require(arg[1])
+nqueens.nqueens(12)

--- a/benchmarks/queen/titan.titan
+++ b/benchmarks/queen/titan.titan
@@ -1,0 +1,49 @@
+-- check whether position (n,c) is free from attacks
+local function isplaceok (a:{integer}, n:integer, c:integer): boolean
+  for i = 1, n - 1 do   -- for each queen already placed
+    local d = a[i]
+    if (d == c) or                -- same column?
+       (d - i == c - n) or        -- same diagonal?
+       (d + i == c + n) then      -- same diagonal?
+      return false            -- place can be attacked
+    end
+  end
+  return true    -- no attacks; place is OK
+end
+
+
+-- print a board
+local function printsolution (N: integer, a:{integer})
+  for i = 1, N do
+    for j = 1, N do
+      if a[i] == j then
+        io_write("X")
+      else
+        io_write("-")
+      end
+      io_write(" ")
+    end
+    io_write("\n")
+  end
+  io_write("\n")
+end
+
+
+-- add to board 'a' all queens from 'n' to 'N'
+local function addqueen (N:integer, a:{integer}, n:integer)
+  if n > N then    -- all queens have been placed?
+    printsolution(N, a)
+  else  -- try to place n-th queen
+    for c = 1, N do
+      if isplaceok(a, n, c) then
+        a[n] = c    -- place n-th queen at column 'c'
+        addqueen(N, a, n + 1)
+      end
+    end
+  end
+end
+
+-- run the program
+function nqueens(N:integer)
+    addqueen(N, {}, 1)
+end

--- a/spec/checker_spec.lua
+++ b/spec/checker_spec.lua
@@ -1274,6 +1274,25 @@ describe("Titan type checker", function()
             errs, nil, true)
     end)
 
+    it("typechecks io.write", function()
+        local prog, errs = run_checker([[
+            function f()
+                io_write("Hello World\n")
+            end
+        ]])
+        assert.truthy(prog, errs)
+    end)
+
+    it("typechecks io.write (error)", function()
+        local prog, errs = run_checker([[
+            function f()
+                io_write(17)
+            end
+        ]])
+        assert.falsy(prog)
+        assert.match("expected string but found integer", errs, nil, true)
+    end)
+
     it("typechecks table.insert", function()
         local prog, errs = run_checker([[
             function f(xs: {integer})

--- a/spec/coder_spec.lua
+++ b/spec/coder_spec.lua
@@ -833,4 +833,19 @@ describe("Titan coder /", function()
             ]])
         end)
     end)
+
+    describe("I/O", function()
+        setup(compile([[
+            function write(s:string)
+                io_write(s)
+            end
+        ]]))
+
+        it("Can run io.write without crashing", function()
+            -- todo: check if the output is correct as well...
+            run_test([[
+                test.write(":)")
+            ]])
+        end)
+    end)
 end)

--- a/spec/coder_test_operators.lua
+++ b/spec/coder_test_operators.lua
@@ -22,15 +22,15 @@ end
 
 local function check(f_lua, f_titan, ...)
     local ok_lua,   r_lua   = pcall(f_lua, ...)
-    local ok_titan, b_titan = pcall(f_titan, ...)
+    local ok_titan, r_titan = pcall(f_titan, ...)
     if ok_lua ~= ok_titan then
         return false, string.format("lua %s but titan %s",
-            (ok1 and "didn't crash" or "crashed"),
-            (ok2 and "didn't crash" or "crashed"))
+            (ok_lua   and "didn't crash" or "crashed"),
+            (ok_titan and "didn't crash" or "crashed"))
     end
-    if ok_lua and ok_titan and not are_same(a, b) then
+    if ok_lua and ok_titan and not are_same(r_lua, r_titan) then
         return false, string.format("(lua: %s, titan: %s)",
-            tostring(a), tostring(b))
+            tostring(r_lua), tostring(r_titan))
     end
     return true
 end

--- a/titan-compiler/builtins.lua
+++ b/titan-compiler/builtins.lua
@@ -1,6 +1,7 @@
 local ast = require "titan-compiler.ast"
 
 return {
+    io_write     = ast.Toplevel.Builtin(false, "io.write"),
     table_insert = ast.Toplevel.Builtin(false, "table.insert"),
     table_remove = ast.Toplevel.Builtin(false, "table.remove"),
 }

--- a/titan-compiler/checker.lua
+++ b/titan-compiler/checker.lua
@@ -419,7 +419,13 @@ local function check_exp_callfunc_builtin(exp, errors)
     local fexp = exp.exp
     local args = exp.args
     local builtin_name = fexp._type.builtin_decl.name
-    if builtin_name == "table.insert" then
+    if builtin_name == "io.write" then
+        check_arity("io.write arguments", 1, #args, errors, exp.loc)
+        check_exp(args[1], errors, nil)
+        checkmatch("io.write argument",
+            types.T.String(), args[1]._type, errors, args[1].loc)
+        exp._type = types.T.Void()
+    elseif builtin_name == "table.insert" then
         check_arity("table.insert arguments", 2, #args, errors, exp.loc)
         check_exp(args[1], errors, nil)
         check_is_array("table.insert first argument",


### PR DESCRIPTION
This limited version of io.write only accepts a single argument of type string and does not respect the "current output file" set by io.outout()