### PR TITLE
C parser cleanups

### DIFF
--- a/c-parser/c99.lua
+++ b/c-parser/c99.lua
@@ -28,6 +28,7 @@
 local c99 = {}
 
 local re = require("relabel")
+local typed = require("typed")
 
 local defs = {}
 
@@ -54,10 +55,16 @@ local function elem(xs, e)
     return false
 end
 
-defs["store_typedef"] = function(s, i, decl)
+defs["decl_func"] = typed("string, number, table -> boolean, Decl", function(_, _, decl)
+    typed.set_type(decl, "Decl")
+    return true, decl
+end)
+
+defs["decl_ids"] = typed("string, number, table -> boolean, Decl?", function(_, _, decl)
+    -- store typedef
     if elem(decl.spec, "typedef") then
         if not (decl.ids and decl.ids[1] and decl.ids[1].decl) then
-            return false
+            return false, nil
         end
         for _, id in ipairs(decl.ids) do
             local name = id.decl.name or id.decl.declarator.name
@@ -66,10 +73,11 @@ defs["store_typedef"] = function(s, i, decl)
             end
         end
     end
+    typed.set_type(decl, "Decl")
     return true, decl
-end
+end)
 
-defs["is_typedef"] = function(s, i, id)
+defs["is_typedef"] = function(_, _, id)
     --print("is " .. id .. " a typedef? " .. tostring(not not typedefs[id]))
     return typedefs[id], typedefs[id] and id
 end
@@ -77,6 +85,54 @@ end
 defs["empty_table"] = function()
     return true, {}
 end
+
+-- Flatten nested expression tables
+defs["nest_exp"] = typed("string, number, {Exp} -> boolean, Exp", function(_, _, exp)
+    typed.set_type(exp, "Exp")
+    if not exp.op then
+        return true, exp[1]
+    end
+    return true, exp
+end)
+
+-- Primary expression tables
+defs["prim_exp"] = typed("string, number, {string} -> boolean, Exp", function(_, _, exp)
+    typed.set_type(exp, "Exp")
+    return true, exp
+end)
+
+-- Type tables
+defs["type_exp"] = typed("string, number, table -> boolean, Exp", function(_, _, exp)
+    typed.check(exp[1], "Type")
+    typed.set_type(exp, "Exp")
+    return true, exp
+end)
+
+-- Types
+defs["type"] = typed("string, number, table -> boolean, Type", function(_, _, typ)
+    typed.set_type(typ, "Type")
+    return true, typ
+end)
+
+defs["join"] = typed("string, number, {array} -> boolean, array", function(_, _, xss)
+    -- xss[1] .. xss[2]
+    if xss[2] then
+        table.move(xss[2], 1, #xss[2], #xss[1] + 1, xss[1])
+    end
+    return true, xss[1] or {}
+end)
+
+defs["postfix"] = typed("string, number, table -> boolean, table", function(_, _, pf)
+    typed.check(pf[1], "Exp")
+    if pf.postfix ~= "" then
+        pf[1].postfix = pf.postfix
+    end
+    return true, pf[1]
+end)
+
+defs["litstruct"] = typed("string, number, number -> boolean, string", function(_, _, _)
+    return true, "litstruct"
+end)
 
 --==============================================================================
 -- Lexical Rules (used in both preprocessing and language processing)
@@ -95,7 +151,7 @@ IDENTIFIER <- { identifierNondigit (identifierNondigit / [0-9])* } _
 identifierNondigit <- [a-zA-Z_]
                     / universalCharacterName
 
-identifierList <- IDENTIFIER ("," _ IDENTIFIER)*
+identifierList <- {| IDENTIFIER ("," _ IDENTIFIER)* |}
 
 --------------------------------------------------------------------------------
 -- Universal Character Names
@@ -184,17 +240,17 @@ local common_expression_rules = [[--lpeg.re
 --------------------------------------------------------------------------------
 -- Common Expression Rules
 
-multiplicativeExpression <- {| castExpression           ({:op: [*/%]                     :} _ castExpression                        )* |}
-additiveExpression       <- {| multiplicativeExpression ({:op: [-+]                      :} _ multiplicativeExpression              )* |}
-shiftExpression          <- {| additiveExpression       ({:op: ("<<" / ">>")             :} _ additiveExpression                    )* |}
-relationalExpression     <- {| shiftExpression          ({:op: (">=" / "<=" / "<" / ">") :} _ shiftExpression                       )* |}
-equalityExpression       <- {| relationalExpression     ({:op: ("==" / "!=")             :} _ relationalExpression                  )* |}
-bandExpression           <- {| equalityExpression       ({:op: "&"                       :} _ equalityExpression                    )* |}
-bxorExpression           <- {| bandExpression           ({:op: "^"                       :} _ bandExpression                        )* |}
-borExpression            <- {| bxorExpression           ({:op: "|"                       :} _ bxorExpression                        )* |}
-andExpression            <- {| borExpression            ({:op: "&&"                      :} _ borExpression                         )* |}
-orExpression             <- {| andExpression            ({:op: "||"                      :} _ andExpression                         )* |}
-conditionalExpression    <- {| orExpression             ({:op: "?"                       :} _ expression ":" _ conditionalExpression)? |}
+multiplicativeExpression <- {| castExpression           ({:op: [*/%]                     :} _ castExpression                        )* |} => nest_exp
+additiveExpression       <- {| multiplicativeExpression ({:op: [-+]                      :} _ multiplicativeExpression              )* |} => nest_exp
+shiftExpression          <- {| additiveExpression       ({:op: ("<<" / ">>")             :} _ additiveExpression                    )* |} => nest_exp
+relationalExpression     <- {| shiftExpression          ({:op: (">=" / "<=" / "<" / ">") :} _ shiftExpression                       )* |} => nest_exp
+equalityExpression       <- {| relationalExpression     ({:op: ("==" / "!=")             :} _ relationalExpression                  )* |} => nest_exp
+bandExpression           <- {| equalityExpression       ({:op: "&"                       :} _ equalityExpression                    )* |} => nest_exp
+bxorExpression           <- {| bandExpression           ({:op: "^"                       :} _ bandExpression                        )* |} => nest_exp
+borExpression            <- {| bxorExpression           ({:op: "|"                       :} _ bxorExpression                        )* |} => nest_exp
+andExpression            <- {| borExpression            ({:op: "&&"                      :} _ borExpression                         )* |} => nest_exp
+orExpression             <- {| andExpression            ({:op: "||"                      :} _ andExpression                         )* |} => nest_exp
+conditionalExpression    <- {| orExpression             ({:op: "?"                       :} _ expression ":" _ conditionalExpression)? |} => nest_exp
 
 constantExpression <- conditionalExpression
 
@@ -214,12 +270,12 @@ translationUnit <- %s* {| externalDeclaration* |} "$EOF$"
 externalDeclaration <- functionDefinition
                      / declaration
 
-functionDefinition <- {| {:spec: {| declarationSpecifier+ |} :} {:func: declarator :} {:decls: declaration* :} {:code: compoundStatement :} |}
+functionDefinition <- {| {:spec: {| declarationSpecifier+ |} :} {:func: declarator :} {:decls: declaration* :} {:code: compoundStatement :} |} => decl_func
 
 --------------------------------------------------------------------------------
 -- Declarations
 
-declaration <- {| {:spec: {| declarationSpecifier+ |} :} ({:ids: initDeclarationList :})? gccExtensionSpecifier* ";" _ |} => store_typedef
+declaration <- {| {:spec: {| declarationSpecifier+ |} :} ({:ids: initDeclarationList :})? gccExtensionSpecifier* ";" _ |} => decl_ids
 
 declarationSpecifier <- storageClassSpecifier
                       / typeSpecifier
@@ -235,7 +291,7 @@ gccExtensionSpecifier <- "__attribute__" _ "(" _ "(" _ gccAttributeList ")" _ ")
 
 gccAsm <- "__asm__" _ "(" _ (STRING_LITERAL / ":" _ / expression)+ ")" _
 
-gccAttributeList <- gccAttributeItem ("," _ gccAttributeItem )*
+gccAttributeList <- {| gccAttributeItem ("," _ gccAttributeItem )* |}
 
 gccAttributeItem <- IDENTIFIER ("(" _ (expression ("," _ expression)*)? ")" _)?
                   / ""
@@ -276,22 +332,22 @@ structOrUnion <- { "struct" } _
 anonymousUnion <- {| {:type: {| {:type: { "union" } :} _ "{" _ {:fields: {| structDeclaration+ |} :} "}" _ |} :} |} ";" _
 
 structDeclaration <- anonymousUnion
-                   / {| {:type: {| specifierQualifier+ |} :} {:ids: {| structDeclaratorList |} :} |} ";" _
+                   / {| {:type: {| specifierQualifier+ |} :} {:ids: structDeclaratorList :} |} ";" _
 
 specifierQualifier <- typeSpecifier
                     / typeQualifier
 
-structDeclaratorList <- structDeclarator ("," _ structDeclarator)*
+structDeclaratorList <- {| structDeclarator ("," _ structDeclarator)* |}
 
 structDeclarator <- declarator? ":" _ constantExpression
                   / declarator
 
-enumSpecifier <- {| {:type: enum :} ({:id: IDENTIFIER :})? "{" _ {:values: {| enumeratorList |} :} ("," _)? "}" _ |}
+enumSpecifier <- {| {:type: enum :} ({:id: IDENTIFIER :})? "{" _ {:values: enumeratorList :} ("," _)? "}" _ |}
                / {| {:type: enum :}  {:id: IDENTIFIER :}                                                          |}
 
 enum <- { "enum" } _
 
-enumeratorList <- enumerator ("," _ enumerator)*
+enumeratorList <- {| enumerator ("," _ enumerator)* |}
 
 enumerator <- {| {:id: enumerationConstant :} ("=" _ {:value: constantExpression :})? |}
 
@@ -303,19 +359,20 @@ ddRec <- "[" _ {| {:idx: typeQualifier* assignmentExpression?          :} |} "]"
        / "[" _ {| {:idx: { "static" } _ typeQualifier* assignmentExpression :} |} "]" _ ddRec
        / "[" _ {| {:idx: typeQualifier+ { "static" } _ assignmentExpression :} |} "]" _ ddRec
        / "[" _ {| {:idx: typeQualifier* { "*" } _                           :} |} "]" _ ddRec
-       / "(" _ {:params: {| parameterTypeList |} :} ")" _ ddRec
-       / "(" _ {:params: {| identifierList?   |} :} ")" _ ddRec
+       / "(" _ {:params: parameterTypeList :} ")" _ ddRec
+       / "(" _ {:params: identifierList? :} ")" _ ddRec
        / ""
 
 pointer <- {| ({ "*" } _ typeQualifier*)+ |}
 
-parameterTypeList <- parameterList ("," _ { "..." } _)?
+parameterTypeList <- {| parameterList "," _ {| { "..." } |} _ |} => join
+                   / parameterList
 
-parameterList <- parameterDeclaration ("," _ parameterDeclaration)*
+parameterList <- {| parameterDeclaration ("," _ parameterDeclaration)* |}
 
 parameterDeclaration <- {| {:param: {| {:type: {| declarationSpecifier+ |} :} {:id: (declarator / abstractDeclarator?) :} |} :} |}
 
-typeName <- specifierQualifier+ abstractDeclarator?
+typeName <- {| specifierQualifier+ abstractDeclarator? |} => type
 
 abstractDeclarator <- pointer? directAbstractDeclarator
                     / pointer
@@ -329,9 +386,9 @@ directAbstractDeclarator2 <- "[" _ assignmentExpression? "]" _
 typedefName <- IDENTIFIER => is_typedef
 
 initializer <- assignmentExpression
-             / {| "{" _ initializerList ("," _)? "}" |} _
+             / "{" _ initializerList ("," _)? "}" _
 
-initializerList <- initializerList2 ("," _ initializerList2)*
+initializerList <- {| initializerList2 ("," _ initializerList2)* |}
 initializerList2 <- designation? initializer
 
 designation <- designator+ "=" _
@@ -379,14 +436,14 @@ jumpStatement <- "goto" _ IDENTIFIER ";" _
 -- Advanced Language Expression Rules
 -- (which require type names)
 
-postfixExpression <- {| "(" _ {:struct: typeName :} ")" _ "{" _ initializerList ("," _)? "}" _ peRec |}
-                   / {| primaryExpression peRec |}
+postfixExpression <- {| {:op: {} => litstruct :} "(" _ {:struct: typeName :} ")" _ "{" _ {:vals: initializerList :} ("," _)? "}" _ peRec |} => nest_exp
+                   / {| primaryExpression {:postfix: peRec :} |} => postfix
 
-sizeofOrPostfixExpression <- {| {:op: "sizeof" :} _ "(" _ typeName ")" _ |}
-                           / {| {:op: "sizeof" :} _ unaryExpression      |}
+sizeofOrPostfixExpression <- {| {:op: "sizeof" :} _ "(" _ typeName ")" _ |} => type_exp
+                           / {| {:op: "sizeof" :} _ unaryExpression |} => nest_exp
                            / postfixExpression
 
-castExpression <- "(" _ typeName ")" _ castExpression
+castExpression <- {| "(" _ typeName ")" _ castExpression |} => type_exp
                 / unaryExpression
 
 ]]
@@ -401,7 +458,7 @@ local language_expression_rules = [[--lpeg.re
 -- Language Expression Rules
 -- (rules which differ from preprocessing stage)
 
-expression <- {| assignmentExpression ("," _ assignmentExpression)* |}
+expression <- {| assignmentExpression ({:op: "," :} _ assignmentExpression)* |} => nest_exp
 
 constant <- ( FLOATING_CONSTANT
             / INTEGER_CONSTANT
@@ -409,23 +466,23 @@ constant <- ( FLOATING_CONSTANT
             / enumerationConstant
             )
 
-primaryExpression <- constant
-                   / IDENTIFIER
-                   / STRING_LITERAL+
+primaryExpression <- {| constant |} => prim_exp
+                   / {| IDENTIFIER |} => prim_exp
+                   / {| STRING_LITERAL+ |} => prim_exp
                    / "(" _ expression ")" _
 
 peRec <- {| "[" _ {:idx: expression :} "]" _ peRec |}
-       / {| "(" _ {:args: (argumentExpressionList / EMPTY_TABLE) :} ")" _ peRec |}
+       / {| "(" _ {:args: (argumentExpressionList / EMPTY_TABLE) :} ")"  _ peRec |}
        / {| "." _ {:dot: IDENTIFIER :} peRec |}
        / {| "->" _ {:arrow: IDENTIFIER :} peRec |}
-       / { "++" } _ peRec
-       / { "--" } _ peRec
+       / {| "++" _ peRec |}
+       / {| "--" _ peRec |}
        / ""
 
-argumentExpressionList <- assignmentExpression ("," _ assignmentExpression)*
+argumentExpressionList <- {| assignmentExpression ("," _ assignmentExpression)* |}
 
-unaryExpression <- {| {:preop: prefixOp :} unaryExpression     |}
-                 / {| {:unop: unaryOperator :} castExpression  |}
+unaryExpression <- {| {:op: prefixOp :} unaryExpression     |} => nest_exp
+                 / {| {:op: unaryOperator :} castExpression  |} => nest_exp
                  / sizeofOrPostfixExpression
 
 prefixOp <- { "++" } _
@@ -462,7 +519,7 @@ local simplified_language_expression_rules = [[--lpeg.re
 -- Simplified Language Expression Rules
 -- (versions that do not require knowledge of type names)
 
-postfixExpression <- {| primaryExpression peRec |}
+postfixExpression <- {| primaryExpression {:postfix: peRec :} |} => postfix
 
 sizeofOrPostfixExpression <- postfixExpression
 
@@ -476,34 +533,36 @@ castExpression <- unaryExpression
 
 local preprocessing_rules = [[--lpeg.re
 
-preprocessingLine <- _ ( "#" _ {| directive |} _
-                       / {| preprocessingTokens? |} _
-                       / "#" _ preprocessingTokens? _ -- non-directive, ignore
+preprocessingLine <- _ ( "#" _ directive _
+                       / {| preprocessingTokenList? _ |} => join
+                       / "#" _ preprocessingTokenList? {| _ |} -- non-directive, ignore
                        )
 
-preprocessingTokens <- {| (preprocessingToken _)+ |}
+preprocessingTokenList <- {| (preprocessingToken _)+ |}
 
-directive <- {:directive: "if"      :} S {:exp: preprocessingTokens :}
-           / {:directive: "ifdef"   :} S {:id: IDENTIFIER :}
-           / {:directive: "ifndef"  :} S {:id: IDENTIFIER :}
-           / {:directive: "elif"    :} S {:exp: preprocessingTokens :}
-           / {:directive: "else"    :}
-           / {:directive: "endif"   :}
-           / {:directive: "include" :} S {:exp: headerName :}
-           / {:directive: "define"  :} S {:id: IDENTIFIER :} "(" _ {:args: {| defineArgs |} :} _ ")" _ {:repl: replacementList :}
-           / {:directive: "define"  :} S {:id: IDENTIFIER :} _ {:repl: replacementList :}
-           / {:directive: "undef"   :} S {:id: IDENTIFIER :}
-           / {:directive: "line"    :} S {:line: preprocessingTokens :}
-           / {:directive: "error"   :} S {:error: preprocessingTokens? :}
-           / {:directive: "pragma"  :} S {:pragma: preprocessingTokens? :}
+directive <- {| {:directive: "if"      :} S {:exp: preprocessingTokenList :} |}
+           / {| {:directive: "ifdef"   :} S {:id: IDENTIFIER :} |}
+           / {| {:directive: "ifndef"  :} S {:id: IDENTIFIER :} |}
+           / {| {:directive: "elif"    :} S {:exp: preprocessingTokenList :} |}
+           / {| {:directive: "else"    :} |}
+           / {| {:directive: "endif"   :} |}
+           / {| {:directive: "include" :} S {:exp: headerName :} |}
+           / {| {:directive: "define"  :} S {:id: IDENTIFIER :} "(" _ {:args: defineArgList :} _ ")" _ {:repl: replacementList :} |}
+           / {| {:directive: "define"  :} S {:id: IDENTIFIER :} _ {:repl: replacementList :} |}
+           / {| {:directive: "undef"   :} S {:id: IDENTIFIER :} |}
+           / {| {:directive: "line"    :} S {:line: preprocessingTokenList :} |}
+           / {| {:directive: "error"   :} S {:error: preprocessingTokenList? :} |}
+           / {| {:directive: "error"   :} |}
+           / {| {:directive: "pragma"  :} S {:pragma: preprocessingTokenList? :} |}
            / gccDirective
            / ""
 
-gccDirective <- {:directive: "include_next" :} S {:exp: headerName :}
+gccDirective <- {| {:directive: "include_next" :} S {:exp: headerName :} |}
+              / {| {:directive: "warning" :} S {:exp: preprocessingTokenList? :} |}
 
-defineArgs <- { "..." }
-            / identifierList _ "," _ { "..." }
-            / identifierList?
+defineArgList <- {| { "..." } |}
+               / {| identifierList _ "," _ { "..." } |} => join
+               / identifierList?
 
 replacementList <- {| (preprocessingToken _)* |}
 
@@ -560,17 +619,17 @@ constant <- FLOATING_CONSTANT
           / INTEGER_CONSTANT
           / CHARACTER_CONSTANT
 
-primaryExpression <- IDENTIFIER
-                   / constant
-                   / {| "(" _ expression _ ")" _ |}
+primaryExpression <- {| IDENTIFIER |} => prim_exp
+                   / {| constant |} => prim_exp
+                   / "(" _ expression _ ")" _
 
 postfixExpression <- primaryExpression peRec
 peRec <- "(" _ argumentExpressionList? ")" _ peRec
        / ""
 
-argumentExpressionList <- {| { expression } ("," _ { expression } )* |}
+argumentExpressionList <- {| expression ("," _ expression )* |}
 
-unaryExpression <- {| {:op: unaryOperator :} {:exp: unaryExpression :} |}
+unaryExpression <- {| {:op: unaryOperator :} unaryExpression |} => nest_exp
                  / primaryExpression
 
 unaryOperator <- { [-+~!] } _

--- a/c-parser/cdriver.lua
+++ b/c-parser/cdriver.lua
@@ -6,7 +6,7 @@ local ctypes = require("c-parser.ctypes")
 local cdefines = require("c-parser.cdefines")
 
 function cdriver.process_file(filename)
-    local ctx, err = cpp.parse_file(filename)
+    local ctx, err = cpp.parse_file(filename, nil, nil)
     if not ctx then
         return nil, "failed preprocessing '"..filename.."': " .. err
     end
@@ -17,8 +17,6 @@ function cdriver.process_file(filename)
     if not res then
         return nil, ("failed parsing: %s:%d:%d: %s\n"):format(filename, line, col, err)
     end
-
-    res = cpp.remove_wrapping_subtables(res)
 
     local ffi_types, err = ctypes.register_types(res)
     if not ffi_types then

--- a/c-parser/cpp.lua
+++ b/c-parser/cpp.lua
@@ -168,6 +168,7 @@ local states = {
         single_char = true,
         silent = true,
         ["/"] = { silent = true, next = "any" },
+        ["*"] = { silent = true, next = "try_end_block_comment" },
         default = { silent = true, next = "block_comment" },
         continue_line = "block_comment",
     },

--- a/c-parser/ctypes.lua
+++ b/c-parser/ctypes.lua
@@ -342,7 +342,7 @@ local function is_void(param)
     return #param.type == 1 and param.type[1] == "void"
 end
 
-local function get_params(lst, params_src)
+local get_params = typed("TypeList, array -> array, boolean", function(lst, params_src)
     local params = {}
     local vararg = false
 
@@ -362,20 +362,16 @@ local function get_params(lst, params_src)
         end
     end
     return params, vararg
-end
+end)
 
 local register_many = function(register_item_fn, lst, ids, spec)
-    if #ids > 0 then
-        for _, id in ipairs(ids) do
-            local ok, err = register_item_fn(lst, id, spec)
-            if not ok then
-                return false, err
-            end
+    for _, id in ipairs(ids) do
+        local ok, err = register_item_fn(lst, id, spec)
+        if not ok then
+            return false, err
         end
-        return true, nil
-    else
-        return register_item_fn(lst, ids, spec)
     end
+    return true, nil
 end
 
 local register_decl_item = function(lst, id, spec)
@@ -516,7 +512,7 @@ ctypes.register_types = typed("{Decl} -> TypeList?, string?", function(parsed)
             end
         elseif not item.ids then
             -- forward declaration (e.g. "struct foo;")
-        elseif item.ids.decl then
+        elseif item.ids then
             local ok, err = register_decls(lst, item.ids, item.spec)
             if not ok then
                 return nil, err or "failed declaration"

--- a/typed.lua
+++ b/typed.lua
@@ -1,0 +1,172 @@
+--------------------------------------------------------------------------------
+-- Lua programming with types
+--------------------------------------------------------------------------------
+
+local _, inspect = pcall(require, "inspect")
+inspect = inspect or tostring
+
+local typed = {}
+
+local FAST = false
+
+local function is_sequence(xs)
+   if type(xs) ~= "table" then
+      return false
+   end
+   if FAST then
+      return true
+   end
+   local l = #xs
+   for k, _ in pairs(xs) do
+      if type(k) ~= "number" or k < 1 or k > l or math.floor(k) ~= k then
+         return false
+      end
+   end
+   return true
+end
+
+local function type_of(t)
+   local mt = getmetatable(t)
+   return (mt and mt.__name) or (is_sequence(t) and "array") or type(t)
+end
+
+local function set_type(t, typ)
+   local mt = getmetatable(t)
+   if not mt then
+      mt = {}
+   end
+   mt.__name = typ
+   return setmetatable(t, mt)
+end
+
+local function typed_table(typ, t)
+   return set_type(t, typ)
+end
+
+local function try_check(val, expected)
+   local optional = expected:match("^(.*)%?$")
+   if optional then
+      if val == nil then
+         return true
+      end
+      expected = optional
+   end
+
+   local seq_type = expected:match("^{(.+)}$")
+   if seq_type then
+      if type(val) == "table" then
+         if FAST then
+            return true
+         end
+         local allok = true
+         for _, v in ipairs(val) do
+            local ok = try_check(v, seq_type)
+            if not ok then
+               allok = false
+               break
+            end
+         end
+         if allok then
+            return true
+         end
+      end
+   end
+
+   -- if all we want is a table, don't perform further checks
+   if expected == "table" and type(val) == "table" then
+      return true
+   end
+
+   local actual = type_of(val)
+   if actual == expected then
+      return true
+   end
+   return nil, actual
+end
+
+local function typed_check(val, expected, category, n)
+   local ok, actual = try_check(val, expected)
+   if ok then
+      return true
+   end
+   if category and n then
+      error(("type error: %s %d: expected %s, got %s (%s)"):format(category, n, expected, actual, inspect(val)), category == "value" and 2 or 3)
+   else
+      error(("type error: expected %s, got %s (%s)"):format(expected, actual, inspect(val)), 2)
+   end
+end
+
+local function split(s, sep)
+   local i, j, k = 1, s:find(sep, 1)
+   local out = {}
+   while j do
+      table.insert(out, s:sub(i, j - 1))
+      i = k + 1
+      j, k = s:find(sep, i)
+   end
+   table.insert(out, s:sub(i, #s))
+   return out
+end
+
+local function typed_function(types, fn)
+   local inp, outp = types:match("(.*[^%s])%s*%->%s*([^%s].*)")
+   local ins = split(inp, ",%s*")
+   local outs = split(outp, ",%s*")
+   return function(...)
+      local args = table.pack(...)
+      if args.n ~= #ins then
+         error("wrong number of inputs (given " .. args.n .. " - expects " .. types .. ")", 2)
+      end
+      for i = 1, #ins do
+         typed_check(args[i], ins[i], "argument", i)
+      end
+      local rets = table.pack(fn(...))
+      if outp == "()" then
+         if rets.n ~= 0 then
+            error("wrong number of outputs (given " .. rets.n .. " - expects " .. types .. ")", 2)
+         end
+      else
+         if rets.n ~= #outs then
+            error("wrong number of outputs (given " .. rets.n .. " - expects " .. types .. ")", 2)
+         end
+         if outs[1] ~= "*" then
+            for i = 1, #outs do
+               typed_check(rets[i], outs[i], "return", i)
+            end
+         end
+      end
+      return table.unpack(rets, 1, rets.n)
+   end
+end
+
+local typed_mt_on = {
+   __call = function(_, types, fn)
+       return typed_function(types, fn)
+   end
+}
+
+local typed_mt_off = {
+   __call = function(_, _, fn)
+       return fn
+   end
+}
+
+function typed.on()
+   typed.check = typed_check
+   typed.typed = typed_function
+   typed.set_type = set_type
+   typed.table = typed_table
+   setmetatable(typed, typed_mt_on)
+end
+
+function typed.off()
+   typed.check = function() end
+   typed.typed = function(_, fn) return fn end
+   typed.set_type = function(t, _) return t end
+   typed.table = function(_, t) return t end
+   setmetatable(typed, typed_mt_off)
+end
+
+typed.off()
+
+return typed


### PR DESCRIPTION
Assorted cleanups in the C parser and preprocessor, also improving its conformance (read: a few more files that used to fail now parse correctly).

(This temporarily bundles the `typed.lua` module in the sources; I plan remove it from here and make it a dependency once it gets a proper release.)