### PR TITLE
Maps

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,7 @@ they are in the roadmap:
 * multiple assignment/multiple returns
 * FFI with C (C pointers, call C functions)
 * records (structs) with methods
+* maps
 
 ## In progress
 
@@ -98,7 +99,6 @@ they are in the roadmap:
 
 ## Next
 
-* maps
 * FFI with C, continued (C arrays, C structs)
 * standard library that is a subset of Lua's standard library, built using the C FFI
 * tagged variants (unions of structs with some syntax for switch/case on the tag)

--- a/doc/manual.md
+++ b/doc/manual.md
@@ -148,6 +148,50 @@ Lua, to instantiate records from the Lua side:
 As nominal types, two records types are incompatible even if they have
 the same structure.
 
+### Maps
+
+Titan supports maps (also known as associative arrays). Map types in Titan are
+structural: you declare a map type by listing the type of keys and values. The
+following example declares a map with float keys and boolean arguments:
+
+    local my_map: {float: boolean} = {}
+
+If a map constructor is given, the type can be inferred:
+
+    local my_map = { [2.5] = true, [3.14] = false }
+
+Map constructors need to use the bracketed syntax for keys, even for string
+types. So a map with string keys can be declared like this:
+
+    local a_map = { ["foo"] = 12, ["bar"] = 13 }
+
+Maps can be indexed and assigned to:
+
+    local fs: {float: string} = {}
+    fs[1.5] = "foo "
+    fs[2.5] = "bar"
+    return fs[1.5] .. fs[2.5]
+
+All types other than `nil` can be used as keys, and all types can be used as
+values.
+
+You can send a map to Lua and then access its keys from Lua normally, where it
+will appear as a Lua table. Lua can send the map back to Titan, as well.
+
+    -- this is Titan code
+    function modify_map(m: {string:boolean}): {string:boolean}
+        m["hello"] = true
+        return m
+    end
+
+    -- this is Lua code
+    local mod = require "titan_module"
+    local t = { ["world"] = false }
+    local t2 = mod.modify_map(t)
+    assert(t == t2)
+    assert(t.hello == true)
+    assert(t.world == false)
+
 ### The `value` type
 
 If you declare that something has type `value` than it can hold values of any
@@ -364,7 +408,11 @@ Here is the complete syntax of Titan in extended BNF. As usual in extended BNF, 
 
     parlist ::= Name ':' type {',' Name ':' type}
 
-    type ::= value | integer | float | boolean | string | '{' type '}'
+    type ::= value | integer | float | boolean | string | array | map
+
+    array ::= '{' type '}'
+
+    map ::= '{' type ':' type '}'
 
     recordfields ::= recordfield {recordfield}
 
@@ -389,18 +437,24 @@ Here is the complete syntax of Titan in extended BNF. As usual in extended BNF, 
     explist ::= exp {',' exp}
 
     exp ::= nil | false | true | Numeral | LiteralString |
-        prefixexp | tableconstructor | exp binop exp | unop exp |
+        prefixexp | arrayconstructor | mapconstructor | exp binop exp | unop exp |
         exp as type
 
     prefixexp ::= var | functioncall | '(' exp ')'
 
     functioncall ::= prefixexp args
 
-    args ::= '(' [explist] ')' | tableconstructor | LiteralString
+    args ::= '(' [explist] ')' | arrayconstructor | mapconstructor | LiteralString
 
-    tableconstructor ::= '{' [fieldlist] '}'
+    arrayconstructor ::= '{' [arrayitemlist] '}'
 
-    fieldlist ::= exp {fieldsep exp} [fieldsep]
+    arrayitemlist ::= exp {fieldsep exp} [fieldsep]
+
+    mapconstructor ::= '{' [mapitemlist] '}'
+
+    mapitemlist ::= keyvalue {fieldsep keyvalue} [fieldsep]
+
+    keyvalue :== '[' exp ']' '=' exp
 
     fieldsep ::= ',' | ';'
 

--- a/lua/src/ltable.c
+++ b/lua/src/ltable.c
@@ -538,7 +538,7 @@ const TValue *luaH_getshortstr (Table *t, TString *key) {
 ** "Generic" get version. (Not that generic: not valid for integers,
 ** which may be in array part, nor for floats with integral values.)
 */
-static const TValue *getgeneric (Table *t, const TValue *key) {
+const TValue *getgeneric (Table *t, const TValue *key) {
   Node *n = mainposition(t, key);
   for (;;) {  /* check whether 'key' is somewhere in the chain */
     if (luaV_rawequalobj(gkey(n), key))

--- a/spec/checker_spec.lua
+++ b/spec/checker_spec.lua
@@ -1959,6 +1959,9 @@ describe("Titan typecheck of records", function()
 
             p = Point.new(1, 2)
         ]])
+        assert_type_error("no context", [[
+            p = { foo = 2 }
+        ]])
     end)
 
     it("doesn't typecheck invalid dot operation in record", function()

--- a/spec/checker_spec.lua
+++ b/spec/checker_spec.lua
@@ -302,6 +302,16 @@ describe("Titan type checker", function()
         assert.truthy(ok, err)
     end)
 
+    it("coerces map key", function ()
+        assert_type_check([[
+            function fn()
+                local a: { float: string } = {}
+                local s = a[1]
+                a[1] = s
+            end
+        ]])
+    end)
+
     it("typechecks multiple return values in array initialization", function ()
         local code = [[
             function f(): (integer, integer)

--- a/spec/checker_spec.lua
+++ b/spec/checker_spec.lua
@@ -178,7 +178,7 @@ describe("Titan type checker", function()
         assert.match("variable '%w+' not declared", err)
     end)
 
-    it("catches array expression in indexing is not an array", function()
+    it("catches array expression in indexing is not an array or map", function()
         local code = [[
             function fn(x: integer)
                 x[1] = 2
@@ -186,7 +186,7 @@ describe("Titan type checker", function()
         ]]
         local ok, err = run_checker(code)
         assert.falsy(ok)
-        assert.match("array expression in indexing is not an array", err)
+        assert.match("expression in indexing is not an array or map", err)
     end)
 
     it("accepts correct use of length operator", function()
@@ -202,6 +202,17 @@ describe("Titan type checker", function()
     it("catches wrong use of length operator", function()
         local code = [[
             function fn(x: integer): integer
+                return #x
+            end
+        ]]
+        local ok, err = run_checker(code)
+        assert.falsy(ok)
+        assert.match("trying to take the length", err)
+    end)
+
+    it("catches wrong use of length operator in maps", function()
+        local code = [[
+            function fn(x: {integer: integer}): integer
                 return #x
             end
         ]]
@@ -280,6 +291,17 @@ describe("Titan type checker", function()
         assert.truthy(ok, err)
     end)
 
+    it("allows setting element of map as nil", function ()
+        local code = [[
+            function fn()
+                local m: {string: integer} = { ["a"] = 10, ["b"] = 20, ["c"] = 30 }
+                m["a"] = nil
+            end
+        ]]
+        local ok, err = run_checker(code)
+        assert.truthy(ok, err)
+    end)
+
     it("typechecks multiple return values in array initialization", function ()
         local code = [[
             function f(): (integer, integer)
@@ -291,6 +313,23 @@ describe("Titan type checker", function()
             function fn()
                 local arr: {integer} = { 10, g(), 30, f() }
                 local arr: {integer} = { 10, g(), 30, (g()) }
+            end
+        ]]
+        local ok, err = run_checker(code)
+        assert.truthy(ok, err)
+    end)
+
+    it("typechecks multiple return values in map initialization", function ()
+        local code = [[
+            function f(): (integer, integer)
+                return 10, 20
+            end
+            function g(): (integer, string)
+                return 20, "foo"
+            end
+            function fn()
+                local m1: {string: integer} = { ["a"] = 10, ["b"] = g(), ["c"] = 30, ["d"] = f() }
+                local m2: {string: integer} = { ["a"] = 10, ["b"] = g(), ["c"] = 30, ["d"] = (g()) }
             end
         ]]
         local ok, err = run_checker(code)
@@ -311,7 +350,20 @@ describe("Titan type checker", function()
         assert.match("expected integer but found string", err)
     end)
 
-    it("catches wrong type in multiple return values for array initialization", function ()
+    it("drops extra values in multiple return values for map initialization", function ()
+        local code = [[
+            function g(): (integer, string)
+                return 20, "foo"
+            end
+            function fn()
+                local m: {string: integer} = { ["a"] = 10, ["b"] = g() }
+            end
+        ]]
+        local ok, err = run_checker(code)
+        assert.truthy(ok, err)
+    end)
+
+    it("catches wrong type in multiple return values for multiple assignment", function ()
         local code = [[
             function f(x: integer): (integer, string)
                 return x * 2, "foo"
@@ -337,6 +389,29 @@ describe("Titan type checker", function()
         local ok, err = run_checker(code)
         assert.falsy(ok)
         assert.match("initializing field 'x' when expecting array", err)
+    end)
+
+    it("catches named init list assigned to a map", function()
+        local code = [[
+            function fn(x: integer)
+                local m: {integer: string} = { x = 10 }
+            end
+        ]]
+        local ok, err = run_checker(code)
+        assert.falsy(ok)
+        assert.match("initializing field 'x' when expecting map", err)
+    end)
+
+    -- FIXME should this be allowed?
+    it("catches named init list assigned to a string-keyed map", function()
+        local code = [[
+            function fn(x: integer)
+                local m: {string: integer} = { x = 10 }
+            end
+        ]]
+        local ok, err = run_checker(code)
+        assert.falsy(ok)
+        assert.match("initializing field 'x' when expecting map", err)
     end)
 
     it("type-checks numeric 'for' (integer, implicit step)", function()
@@ -827,6 +902,17 @@ describe("Titan type checker", function()
         assert.match("cannot concatenate with { integer } value", err)
     end)
 
+    it("cannot concatenate with map", function()
+        local code = [[
+            function fn()
+                local s = "foo" .. { [false] = 2 }
+            end
+        ]]
+        local ok, err = run_checker(code)
+        assert.falsy(ok)
+        assert.match("cannot concatenate with { boolean : integer } value", err)
+    end)
+
     it("cannot concatenate with type value", function()
         local code = [[
             function fn()
@@ -853,6 +939,16 @@ describe("Titan type checker", function()
         it("can compare arrays of same type using " .. op, function()
             local code = [[
                 function fn(a1: {integer}, a2: {integer}): boolean
+                    return a1 ]] .. op .. [[ a2
+                end
+            ]]
+            local ok, err = run_checker(code)
+            assert.truthy(ok)
+        end)
+
+        it("can compare maps of same type using " .. op, function()
+            local code = [[
+                function fn(a1: {string: integer}, a2: {string: integer}): boolean
                     return a1 ]] .. op .. [[ a2
                 end
             ]]
@@ -970,6 +1066,28 @@ describe("Titan type checker", function()
         it("cannot compare arrays of different types using " .. op, function()
             local code = [[
                 function fn(a1: {integer}, a2: {float}): boolean
+                    return a1 ]] .. op .. [[ a2
+                end
+            ]]
+            local ok, err = run_checker(code)
+            assert.falsy(ok)
+            assert.match("trying to compare values of different types", err)
+        end)
+
+        it("cannot compare maps of different value types using " .. op, function()
+            local code = [[
+                function fn(a1: {string: integer}, a2: {string: float}): boolean
+                    return a1 ]] .. op .. [[ a2
+                end
+            ]]
+            local ok, err = run_checker(code)
+            assert.falsy(ok)
+            assert.match("trying to compare values of different types", err)
+        end)
+
+        it("cannot compare maps of different key types using " .. op, function()
+            local code = [[
+                function fn(a1: {integer: string}, a2: {float: string}): boolean
                     return a1 ]] .. op .. [[ a2
                 end
             ]]

--- a/spec/coder_spec.lua
+++ b/spec/coder_spec.lua
@@ -1968,8 +1968,7 @@ describe("Titan code generator", function()
 
     describe("#maps", function()
 
-        -- FIXME
-        pending("Lua can break a map", function ()
+        it("Lua can break a map", function ()
             local code = [[
                 function f(m: {string:integer}): {string:integer}
                     m["foo"] = m["foo"] + 10
@@ -1987,9 +1986,9 @@ describe("Titan code generator", function()
                 local m2 = titan_test.f(m)
                 assert(m2 == m)
                 assert(m.foo == 20)
-                titan_test.f(m)              -- FIXME this is failing here, why?
+                titan_test.f(m)
                 assert(m.foo == 30)
-                m.foo = "wat"
+                m.foo = 'wat'
                 titan_test.f(m) -- supposed to give an error here
             ]])
             assert.falsy(ok)
@@ -2004,8 +2003,7 @@ describe("Titan code generator", function()
             { t = "string", v1 = "'hello'", v2 = "'world'" },
             { t = "{integer}", l1 = "{10, 20}", l2 = "{}" },
             { t = "{string:integer}", l1 = "{x = 10, y = 20}", l2 = "{}"  },
---FIXME record declarations are failing, am I doing it right?
---            { t = "Point", l1 = "titan_test.Point.new(10, 20)", l2 = "titan_test.Point.new(30, 40)" },
+            { t = "Point", l1 = "titan_test.Point.new(10, 20)", l2 = "titan_test.Point.new(30, 40)" },
         }
 
         for _, t1 in ipairs(test_types) do
@@ -2014,10 +2012,10 @@ describe("Titan code generator", function()
 
                 it("declares a map " .. map, function()
                     local code = util.render([[
---                        record Point
---                            x: integer
---                            y: integer
---                        end
+                        record Point
+                            x: integer
+                            y: integer
+                        end
                         function new_map(k1: $TK, k2: $TK, v1: $TV, v2: $TV): $MAP
                             local m = { [$K1] = $V1, [$K2] = $V2 }
                             return m
@@ -2033,7 +2031,7 @@ describe("Titan code generator", function()
                     })
                     local ast, err = parse(code)
                     assert.truthy(ast, err)
-                    local ok, err = checker.check("test", ast, code, "test.titan")
+                    local ok, err = checker.check("titan_test", ast, code, "test.titan")
                     assert.equal(0, #err, table.concat(err, "\n"))
                     local ok, err = driver.compile("titan_test", ast)
                     assert.truthy(ok, err)
@@ -2056,10 +2054,10 @@ describe("Titan code generator", function()
 
                 it("assigns to a map " .. map, function()
                     local code = util.render([[
---                        record Point
---                            x: integer
---                            y: integer
---                        end
+                        record Point
+                            x: integer
+                            y: integer
+                        end
                         function new_map(k1: $TK, k2: $TK, v1: $TV, v2: $TV): $MAP
                             local m: $MAP = {}
                             m[$K1] = $V1
@@ -2077,7 +2075,7 @@ describe("Titan code generator", function()
                     })
                     local ast, err = parse(code)
                     assert.truthy(ast, err)
-                    local ok, err = checker.check("test", ast, code, "test.titan")
+                    local ok, err = checker.check("titan_test", ast, code, "test.titan")
                     assert.equal(0, #err, table.concat(err, "\n"))
                     local ok, err = driver.compile("titan_test", ast)
                     assert.truthy(ok, err)
@@ -2100,10 +2098,10 @@ describe("Titan code generator", function()
 
                 it("indexes a map " .. map, function()
                     local code = util.render([[
---                        record Point
---                            x: integer
---                            y: integer
---                        end
+                        record Point
+                            x: integer
+                            y: integer
+                        end
                         function get_map_value(k1: $TK, k2: $TK, v1: $TV, v2: $TV): $TV
                             local m: $MAP = {}
                             m[$K1] = $V1
@@ -2121,7 +2119,7 @@ describe("Titan code generator", function()
                     })
                     local ast, err = parse(code)
                     assert.truthy(ast, err)
-                    local ok, err = checker.check("test", ast, code, "test.titan")
+                    local ok, err = checker.check("titan_test", ast, code, "test.titan")
                     assert.equal(0, #err, table.concat(err, "\n"))
                     local ok, err = driver.compile("titan_test", ast)
                     assert.truthy(ok, err)

--- a/spec/coder_spec.lua
+++ b/spec/coder_spec.lua
@@ -1968,7 +1968,7 @@ describe("Titan code generator", function()
 
     describe("#maps", function()
 
-        it("Lua can break a map", function ()
+        it("adding a value of the wrong type in Lua can trigger a runtime error later in Titan", function ()
             local code = [[
                 function f(m: {string:integer}): {string:integer}
                     m["foo"] = m["foo"] + 10

--- a/spec/coder_spec.lua
+++ b/spec/coder_spec.lua
@@ -1964,7 +1964,157 @@ describe("Titan code generator", function()
                 assert(0 == test.f(0xdead, math.mininteger))
             ]])
         end)
-end)
+    end)
+
+    describe("#maps", function()
+
+        local types = {
+            { t = "boolean", v1 = "true", v2 = "false" },
+            { t = "integer", v1 = "1984", v2 = "2112" },
+            { t = "float", v1 = "2.5", v2 = "3.14" },
+            { t = "string", v1 = "'hello'", v2 = "'world'" },
+            { t = "{integer}", l1 = "{10, 20}", l2 = "{}" },
+            { t = "{string:integer}", l1 = "{x = 10, y = 20}", l2 = "{}"  },
+--            { t = "Point", l1 = "titan_test.Point.new(10, 20)", l2 = "titan_test.Point.new(30, 40)" },
+        }
+
+        for _, t1 in ipairs(types) do
+            for _, t2 in ipairs(types) do
+                local map = "{" .. t1.t .. " : " .. t2.t .. "}"
+
+                it("declares a map " .. map, function()
+                    local code = util.render([[
+--                        record Point
+--                            x: integer
+--                            y: integer
+--                        end
+                        function new_map(k1: $TK, k2: $TK, v1: $TV, v2: $TV): $MAP
+                            local m = { [$K1] = $V1, [$K2] = $V2 }
+                            return m
+                        end
+                    ]], {
+                        MAP = map,
+                        K1 = t1.v1 or "k1",
+                        K2 = t1.v2 or "k2",
+                        V1 = t2.v1 or "v1",
+                        V2 = t2.v2 or "v2",
+                        TK = t1.t,
+                        TV = t2.t,
+                    })
+                    local ast, err = parse(code)
+                    assert.truthy(ast, err)
+                    local ok, err = checker.check("test", ast, code, "test.titan")
+                    assert.equal(0, #err, table.concat(err, "\n"))
+                    local ok, err = driver.compile("titan_test", ast)
+                    assert.truthy(ok, err)
+                    local ok, err = call("titan_test", util.render([[
+                        local k1, k2, v1, v2 = $LK1, $LK2, $LV1, $LV2
+                        local m = titan_test.new_map(k1, k2, v1, v2)
+                        assert(m[$K1] == $V1 and m[$K2] == $V2)
+                    ]], {
+                        K1 = t1.v1 or "k1",
+                        K2 = t1.v2 or "k2",
+                        V1 = t2.v1 or "v1",
+                        V2 = t2.v2 or "v2",
+                        LK1 = t1.l1 or t1.v1,
+                        LK2 = t1.l2 or t1.v2,
+                        LV1 = t2.l1 or t2.v1,
+                        LV2 = t2.l2 or t2.v2,
+                    }))
+                    assert.truthy(ok, err)
+                end)
+
+                it("assigns to a map " .. map, function()
+                    local code = util.render([[
+--                        record Point
+--                            x: integer
+--                            y: integer
+--                        end
+                        function new_map(k1: $TK, k2: $TK, v1: $TV, v2: $TV): $MAP
+                            local m: $MAP = {}
+                            m[$K1] = $V1
+                            m[$K2] = $V2
+                            return m
+                        end
+                    ]], {
+                        MAP = map,
+                        K1 = t1.v1 or "k1",
+                        K2 = t1.v2 or "k2",
+                        V1 = t2.v1 or "v1",
+                        V2 = t2.v2 or "v2",
+                        TK = t1.t,
+                        TV = t2.t,
+                    })
+                    local ast, err = parse(code)
+                    assert.truthy(ast, err)
+                    local ok, err = checker.check("test", ast, code, "test.titan")
+                    assert.equal(0, #err, table.concat(err, "\n"))
+                    local ok, err = driver.compile("titan_test", ast)
+                    assert.truthy(ok, err)
+                    local ok, err = call("titan_test", util.render([[
+                        local k1, k2, v1, v2 = $LK1, $LK2, $LV1, $LV2
+                        local m = titan_test.new_map(k1, k2, v1, v2)
+                        assert(m[$K1] == $V1 and m[$K2] == $V2)
+                    ]], {
+                        K1 = t1.v1 or "k1",
+                        K2 = t1.v2 or "k2",
+                        V1 = t2.v1 or "v1",
+                        V2 = t2.v2 or "v2",
+                        LK1 = t1.l1 or t1.v1,
+                        LK2 = t1.l2 or t1.v2,
+                        LV1 = t2.l1 or t2.v1,
+                        LV2 = t2.l2 or t2.v2,
+                    }))
+                    assert.truthy(ok, err)
+                end)
+
+                it("indexes a map " .. map, function()
+                    local code = util.render([[
+--                        record Point
+--                            x: integer
+--                            y: integer
+--                        end
+                        function get_map_value(k1: $TK, k2: $TK, v1: $TV, v2: $TV): $TV
+                            local m: $MAP = {}
+                            m[$K1] = $V1
+                            m[$K2] = $V2
+                            return m[$K1]
+                        end
+                    ]], {
+                        MAP = map,
+                        K1 = t1.v1 or "k1",
+                        K2 = t1.v2 or "k2",
+                        V1 = t2.v1 or "v1",
+                        V2 = t2.v2 or "v2",
+                        TK = t1.t,
+                        TV = t2.t,
+                    })
+                    local ast, err = parse(code)
+                    assert.truthy(ast, err)
+                    local ok, err = checker.check("test", ast, code, "test.titan")
+                    assert.equal(0, #err, table.concat(err, "\n"))
+                    local ok, err = driver.compile("titan_test", ast)
+                    assert.truthy(ok, err)
+                    local ok, err = call("titan_test", "v = titan_test.get_map_value(); assert(v == 1984)")
+                    local ok, err = call("titan_test", util.render([[
+                        local k1, k2, v1, v2 = $LK1, $LK2, $LV1, $LV2
+                        local v = titan_test.get_map_value(k1, k2, v1, v2)
+                        assert(v == $V1)
+                    ]], {
+                        K1 = t1.v1 or "k1",
+                        K2 = t1.v2 or "k2",
+                        V1 = t2.v1 or "v1",
+                        V2 = t2.v2 or "v2",
+                        LK1 = t1.l1 or t1.v1,
+                        LK2 = t1.l2 or t1.v2,
+                        LV1 = t2.l1 or t2.v1,
+                        LV2 = t2.l2 or t2.v2,
+                    }))
+                    assert.truthy(ok, err)
+                end)
+            end
+        end
+    end)
 
 end)
 

--- a/spec/coder_spec.lua
+++ b/spec/coder_spec.lua
@@ -2142,6 +2142,26 @@ describe("Titan code generator", function()
                 end)
             end
         end
+
+        it("coerces map key", function ()
+            run_coder([[
+                function fn1(): string
+                    local a: { float: string } = {}
+                    a[1] = 'foo'
+                    return a[1.0]
+                end
+
+                function fn2(): string
+                    local a: { float: string } = {}
+                    a[1.0] = 'foo'
+                    return a[1]
+                end
+            ]], [[
+                assert(test.fn1() == 'foo')
+                assert(test.fn2() == 'foo')
+            ]])
+        end)
+
     end)
 
 end)

--- a/spec/parser_spec.lua
+++ b/spec/parser_spec.lua
@@ -265,6 +265,22 @@ describe("Titan parser", function()
                     {_tag = "Ast.TypeName", name = "int" } } } )
     end)
 
+    it("can parse map types", function()
+        assert_type_ast("{int: string}",
+            { _tag = "Ast.TypeMap",
+              keystype = {_tag = "Ast.TypeName", name = "int" },
+              valuestype = {_tag = "Ast.TypeString" } } )
+
+        assert_type_ast("{{int:string}:{string:int}}",
+            { _tag = "Ast.TypeMap",
+              keystype = { _tag = "Ast.TypeMap",
+                  keystype = {_tag = "Ast.TypeName", name = "int" },
+                  valuestype = {_tag = "Ast.TypeString" } },
+              valuestype = { _tag = "Ast.TypeMap",
+                  keystype = {_tag = "Ast.TypeString" },
+                  valuestype = {_tag = "Ast.TypeName", name = "int" } } } )
+    end)
+
     describe("can parse function types", function()
         it("with parameter lists of length = 0", function()
             assert_type_ast("() -> ()",

--- a/spec/types_spec.lua
+++ b/spec/types_spec.lua
@@ -11,6 +11,7 @@ describe("Titan types", function()
     it("checks if a type is garbage collected", function()
         assert.truthy(types.is_gc(types.String()))
         assert.truthy(types.is_gc(types.Array(types.Integer())))
+        assert.truthy(types.is_gc(types.Map(types.Integer(), types.Integer())))
         assert.truthy(types.is_gc(types.Function({}, {}, false)))
     end)
 

--- a/titan-compiler/ast.lua
+++ b/titan-compiler/ast.lua
@@ -11,6 +11,7 @@ return typedecl("Ast", {
         TypeQualName    = {"loc", "module", "name"},
         TypeName        = {"loc", "name"},
         TypeArray       = {"loc", "subtype"},
+        TypeMap         = {"loc", "keystype", "valuestype"},
         TypeFunction    = {"loc", "argtypes", "rettypes"},
     },
 

--- a/titan-compiler/checker.lua
+++ b/titan-compiler/checker.lua
@@ -98,6 +98,11 @@ typefromnode = util.make_visitor({
         return types.Array(typefromnode(node.subtype, st, errors))
     end,
 
+    ["Ast.TypeMap"] = function(node, st, errors)
+        return types.Map(typefromnode(node.keystype, st, errors),
+                         typefromnode(node.valuestype, st, errors))
+    end,
+
     ["Ast.TypeFunction"] = function(node, st, errors)
         if #node.argtypes ~= 1 then
             error("functions with 0 or 2+ return values are not yet implemented")

--- a/titan-compiler/checker.lua
+++ b/titan-compiler/checker.lua
@@ -481,7 +481,7 @@ checkvar = util.make_visitor({
     end,
 
     ["Ast.VarBracket"] = function(node, st, errors, context)
-        checkexp(node.exp1, st, errors) -- FIXME check this: checkexp(node.exp1, st, errors, context and types.Array(context))
+        checkexp(node.exp1, st, errors)
         local keystype, term
         if node.exp1._type._tag == "Type.Array" then
             node._type = node.exp1._type.elem
@@ -677,7 +677,14 @@ checkexp = util.make_visitor({
                 end
             end
         elseif expected == "Type.Nominal" then
-            if not types.registry[context.fqtn] then
+            if not context then
+                checker.typeerror(errors, node.loc,
+                    "no context to provide type for record constructor")
+                    for _, field in ipairs(node.fields) do
+                        checkexp(field.exp, st, errors)
+                    end
+                    node._type = types.Invalid()
+            elseif not types.registry[context.fqtn] then
                 checker.typeerror(errors, node.loc,
                     "record type '%s' in context of record constructor does not exist",
                     types.tostring(context))

--- a/titan-compiler/parser.lua
+++ b/titan-compiler/parser.lua
@@ -412,7 +412,11 @@ local grammar = re.compile([[
                           !RCURLY %{ExpFieldList}))*
                         fieldsep?)                          -- produces Field...
 
-    field           <- (P  (NAME ASSIGN)? -> opt exp)       -> Field
+    field           <- (P  (key ASSIGN)? -> opt exp)       -> Field
+
+    key             <- NAME
+                     / LBRACKET exp^ExpExpSuf
+                                RBRACKET^RBracketExpSuf
 
     fieldsep        <- SEMICOLON / COMMA
 

--- a/titan-compiler/parser.lua
+++ b/titan-compiler/parser.lua
@@ -278,6 +278,10 @@ local grammar = re.compile([[
                      / (P  NAME DOT NAME^QualName)               -> TypeQualName
                      / (P  NAME)                                 -> TypeName
                      / (P  LCURLY type^TypeType
+                           COLON
+                           type^TypeType
+                           RCURLY^RCurlyType)                    -> TypeMap
+                     / (P  LCURLY type^TypeType
                            RCURLY^RCurlyType)                    -> TypeArray
 
     typelist        <- ( LPAREN


### PR DESCRIPTION
This PR adds maps to Titan, declared with `{ type : type }` syntax and initialized with `{[exp] = exp, ... }`. Semantics are supposed to be straightforward, and the implementation followed that of arrays.

There are two items I'd love to have some help with:

* I couldn't get tests with maps of records to work, they are commented out in the suite
* There is a weird bug in the test that is disabled now with `pending()`

I needed to de-`static`-ify one function in the Lua VM, and then added a forward declaration in the preamble. Not sure if this is the way we've been doing this.

Also, I don't know if the implementation I did in the coder for setting the Lua table is the most efficient one — but it seems to pass the tests! (except for that one...)

Marking this as "wip" until we figure out the `pending` test bug and the map-of-records tests.