### PR TITLE
Support for compiling stand-alone executables

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,9 +45,16 @@ binary path, a semicolon-separated list of paths
 or `TITAN_PATH` environment variable). A module gets compiled if its `.titan` file
 is newer than its binary, or a binary does not exist.
 
-If everything is all right with your modules this will generate shared libraries
-(in the same path as the module source) that you can `require` from Lua, and
-call any exported functions/access exported variables.
+If everything is all right with your modules, you will get the result of
+your compilation as a native binary:
+
+* if one of your Titan modules has a `main` function, with signature
+  `function({string}):integer`, then `titanc` will bundle all modules
+  given in the command-line as a stand-alone executable program.
+* Otherwise, it will compile each module into a shared library
+  (in the same path as the module source) that you can `import` from
+  Titan as well as `require` from Lua, and call any exported
+  functions/access exported variables.
 
 # Running the test suite
 

--- a/doc/manual.md
+++ b/doc/manual.md
@@ -47,6 +47,16 @@ dynamically-typed Lua function from Titan, Titan will check whether the Lua
 function returned the correct types and number of arguments and it will raise a
 run-time error if it does not receive what it expected.
 
+If a module contains a function called `main` with the type signature
+`function({string): integer`, then the Titan module will be compiled as a
+stand-alone program, and the Titan compiler will attempt to link all its
+imported Titan modules statically. This main function will act as the entry
+point to the program: the input argument is an array of strings containing the
+command-line arguments, and the integer return value is the exit code of the
+program. Only one of the modules given to the Titan compiler may contain a
+main function. Any other functions called `main` with different type
+signatures do not qualify as main functions.
+
 #### Rules for function arity
 
 Arity rules for calling functions are strict: if you call a Titan function with

--- a/examples/sdl_demo.titan
+++ b/examples/sdl_demo.titan
@@ -2,7 +2,7 @@
 -- Compile with:
 --    titanc examples.sdl_demo -lSDL2
 -- Run with:
---    lua/src/lua -e 'require("examples.sdl_demo").main()'
+--    ./examples/sdl_demo
 
 local stdio = foreign import "stdio.h"
 local SDL = foreign import "SDL2/SDL.h"
@@ -16,7 +16,7 @@ local function quit(sdlquit: boolean, msg: string)
     stdlib.exit(1)
 end
 
-function main()
+function main(args: {string}): integer
 
     if SDL.SDL_Init(SDL.SDL_INIT_VIDEO) ~= 0 then
         quit(false, "SDL_init error")
@@ -24,7 +24,11 @@ function main()
 
     local SDL_WINDOW_SHOWN = 0x04
 
-    local win = SDL.SDL_CreateWindow("Hello World!", 100, 100, 640, 480, SDL_WINDOW_SHOWN)
+    local title = "Hello World!"
+    if #args > 0 then
+        title = title .. " " .. args[1]
+    end
+    local win = SDL.SDL_CreateWindow(title, 100, 100, 640, 480, SDL_WINDOW_SHOWN)
     if not win then
         quit(true, "SDL_CreateWindow error")
     end
@@ -66,4 +70,5 @@ function main()
     SDL.SDL_DestroyWindow(win)
     SDL.SDL_Quit()
 
+    return 42
 end

--- a/examples/sdl_demo.titan
+++ b/examples/sdl_demo.titan
@@ -4,22 +4,14 @@
 -- Run with:
 --    ./examples/sdl_demo
 
-local stdio = foreign import "stdio.h"
 local SDL = foreign import "SDL2/SDL.h"
-local stdlib = foreign import "stdlib.h"
 
-local function quit(sdlquit: boolean, msg: string)
-    stdio.printf(msg .. ": %s\n", SDL.SDL_GetError())
-    if sdlquit then
-        SDL.SDL_Quit()
-    end
-    stdlib.exit(1)
-end
+local sdl_quit = import "examples.sdl_quit"
 
 function main(args: {string}): integer
 
     if SDL.SDL_Init(SDL.SDL_INIT_VIDEO) ~= 0 then
-        quit(false, "SDL_init error")
+        sdl_quit.quit(false, "SDL_init error")
     end
 
     local SDL_WINDOW_SHOWN = 0x04
@@ -30,7 +22,7 @@ function main(args: {string}): integer
     end
     local win = SDL.SDL_CreateWindow(title, 100, 100, 640, 480, SDL_WINDOW_SHOWN)
     if not win then
-        quit(true, "SDL_CreateWindow error")
+        sdl_quit.quit(true, "SDL_CreateWindow error")
     end
 
     local SDL_RENDERER_ACCELERATED = 0x02
@@ -39,7 +31,7 @@ function main(args: {string}): integer
     local ren = SDL.SDL_CreateRenderer(win, -1, SDL_RENDERER_ACCELERATED | SDL_RENDERER_PRESENTVSYNC)
     if not ren then
         SDL.SDL_DestroyWindow(win)
-        quit(true, "SDL_CreateRenderer error")
+        sdl_quit.quit(true, "SDL_CreateRenderer error")
     end
 
     local bmp = SDL.SDL_LoadBMP_RW(SDL.SDL_RWFromFile("examples/hello.bmp", "rb"), 1)
@@ -47,7 +39,7 @@ function main(args: {string}): integer
     if not bmp then
         SDL.SDL_DestroyRenderer(ren)
         SDL.SDL_DestroyWindow(win)
-        quit(true, "SDL_LoadBMP error")
+        sdl_quit.quit(true, "SDL_LoadBMP error")
     end
 
     local tex = SDL.SDL_CreateTextureFromSurface(ren, bmp)
@@ -55,7 +47,7 @@ function main(args: {string}): integer
     if not tex then
         SDL.SDL_DestroyRenderer(ren)
         SDL.SDL_DestroyWindow(win)
-        quit(true, "SDL_CreateTextureFromSurface error")
+        sdl_quit.quit(true, "SDL_CreateTextureFromSurface error")
     end
 
     for i = 1, 3 do

--- a/titan-compiler/checker.lua
+++ b/titan-compiler/checker.lua
@@ -1398,6 +1398,22 @@ local function checktoplevel(ast, st, errors, loader)
     end
 end
 
+function checker.has_main(ast)
+    for _, node in ipairs(ast) do
+        local name = toplevel_name(node)
+        if name == "main"
+           and node._tag == "Ast.TopLevelFunc"
+           and #node.params == 1
+           and node.params[1]._type._tag == "Type.Array"
+           and node.params[1]._type.elem._tag == "Type.String"
+           and #node.rettypes == 1
+           and node.rettypes[1]._tag == "Ast.TypeInteger" then
+            return true
+        end
+    end
+    return false
+end
+
 function checker.checkimport(modname, loader)
     local ok, type_or_error, errors = loader(modname)
     if not ok then return nil, type_or_error end

--- a/titan-compiler/driver.lua
+++ b/titan-compiler/driver.lua
@@ -100,7 +100,7 @@ function driver.tableloader(modtable, imported)
     return loader
 end
 
-function driver.shared()
+local function shared_flag()
     local shared = "-shared"
     if string.match(driver.UNAME, "Darwin") then
         shared = shared .. " -undefined dynamic_lookup"
@@ -108,26 +108,174 @@ function driver.shared()
     return shared
 end
 
-function driver.compile_module(modname, mod, link)
-    if mod.compiled then return true end
-    local ok, err = driver.compile(modname, mod.ast, mod.filename, link)
-    if not ok then return nil, err end
-    mod.compiled = true
-    return true
+local function static_flag()
+    return "-c"
 end
 
-function driver.compile(modname, ast, sourcef, link)
+function driver.compile_module(modname, mod, link, is_static, verbose)
+    if mod.compiled then return true, mod.compiled end
+    local ok, err, libname = driver.compile(modname, mod.ast, mod.filename, link, is_static, verbose)
+    if not ok then return nil, err end
+    mod.compiled = libname
+    return true, nil, libname
+end
+
+function driver.compile(modname, ast, sourcef, link, is_static, verbose)
     sourcef = sourcef or modname:gsub("[.]", "/") .. ".titan"
     local code = coder.generate(modname, ast)
     code = pretty.reindent_c(code)
     local filename = sourcef:gsub("[.]titan$", "") .. ".c"
-    local soname = sourcef:gsub("[.]titan$", "") .. ".so"
+
+    local libname = sourcef:gsub("[.]titan$", "") .. (is_static and ".o" or ".so")
     os.remove(filename)
-    os.remove(soname)
+    os.remove(libname)
     local ok, err = util.set_file_contents(filename, code)
     if not ok then return nil, err end
-    local args = {driver.CC, driver.CFLAGS, driver.shared(), filename,
-                  "-I", driver.LUA_SOURCE_PATH, "-o", soname}
+    local libflag = is_static and static_flag() or shared_flag()
+    local args = {driver.CC, driver.CFLAGS, libflag, filename,
+                  "-I", driver.LUA_SOURCE_PATH, "-o", libname}
+    if link and not is_static then
+        local libs = util.split_string(link, ",")
+        for _, lib in ipairs(libs) do
+            table.insert(args, "-l" .. lib)
+        end
+    end
+    local cmd = table.concat(args, " ")
+    if verbose then
+        print(cmd)
+    end
+    ok, err = os.execute(cmd)
+    if ok then
+        return ok, nil, libname
+    else
+        return nil, err
+    end
+end
+
+local entrypoint_template = [[
+
+#include <lua.h>
+#include <lualib.h>
+#include <lauxlib.h>
+#include <errno.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+/* portable alerts, from srlua */
+#ifdef _WIN32
+#include <windows.h>
+#define alert(message)  MessageBox(NULL, message, progname, MB_ICONERROR | MB_OK)
+#define getprogname()   char name[MAX_PATH]; argv[0]= GetModuleFileName(NULL,name,sizeof(name)) ? name : NULL;
+#else
+#define alert(message)  fprintf(stderr,"%s: %s\n", "$PROGNAME", message)
+#define getprogname()
+#endif
+
+/* fatal error, from srlua */
+static void fatal(const char* message) {
+    alert(message);
+    exit(EXIT_FAILURE);
+}
+
+/* main script launcher, based on srlua */
+static int pmain(lua_State *L) {
+    int argc = lua_tointeger(L, 1);
+    char** argv = lua_touserdata(L, 2);
+    int i;
+    const char code[] = "local arg = ...;\nreturn\nrequire('$MODNAME').main(arg);";
+    luaL_loadstring(L, code);
+    if (lua_type(L, lua_gettop(L)) == LUA_TSTRING) {
+        fatal(lua_tostring(L, -1));
+    }
+    lua_createtable(L, argc, 0);
+    for (i = 0; i < argc; i++) {
+        lua_pushstring(L, argv[i]);
+        lua_rawseti(L, -2, i);
+    }
+    lua_call(L, 1, 1);
+    return 1;
+}
+
+/* error handler, from luac */
+static int msghandler (lua_State *L) {
+    /* is error object not a string? */
+    const char *msg = lua_tostring(L, 1);
+    if (msg == NULL) {
+        /* does it have a metamethod that produces a string */
+        if (luaL_callmeta(L, 1, "__tostring") && lua_type(L, -1) == LUA_TSTRING) {
+            /* then that is the message */
+            return 1;
+        } else {
+            msg = lua_pushfstring(L, "(error object is a %s value)", luaL_typename(L, 1));
+        }
+    }
+    /* append a standard traceback */
+    luaL_traceback(L, L, msg, 1);
+    return 1;
+}
+
+int $LUAOPEN_FN(lua_State* L);
+
+/* main function, based on srlua */
+int main(int argc, char** argv) {
+    int ret;
+    lua_State* L;
+    getprogname();
+    if (argv[0] == NULL) {
+        fatal("cannot locate this executable");
+    }
+    L = luaL_newstate();
+    if (L == NULL) {
+        fatal("not enough memory for state");
+    }
+    luaL_openlibs(L);
+    lua_getglobal(L, "package");
+    lua_getfield(L, -1, "preload");
+    lua_pushcfunction(L, $LUAOPEN_FN);
+    lua_setfield(L, -2, "$MODNAME");
+    lua_pushcfunction(L, msghandler);
+    lua_pushcfunction(L, pmain);
+    lua_pushinteger(L, argc);
+    lua_pushlightuserdata(L, argv);
+    if (lua_pcall(L, 2, 1, -4) != 0) {
+        fatal(lua_tostring(L, -1));
+    }
+    ret = lua_tointeger(L, -1);
+    lua_close(L);
+    return ret;
+}
+
+]]
+
+local function write_entrypoint(modname)
+    local entrypoint_c = modname:gsub("[.]", "/") .. "__entrypoint.c"
+    local fd, err = io.open(entrypoint_c, "w")
+    if not fd then return nil, err end
+    local ok, err = fd:write(util.render(entrypoint_template, {
+        PROGNAME = modname:gsub(".*[.]", ""),
+        LUAOPEN_FN = "luaopen_" .. modname:gsub("[.]", "_"),
+        MODNAME = modname,
+    }))
+    if err then return nil, err end
+    fd:close()
+    return entrypoint_c
+end
+
+function driver.compile_program(modname, libnames, link, verbose)
+    local execname = modname:gsub("[.]", "/")
+    os.remove(execname)
+
+    local entrypoint_c, err = write_entrypoint(modname)
+    if err then return nil, err end
+
+    local args = {driver.CC, driver.CFLAGS, "-o", execname,
+                  entrypoint_c}
+    for _, libname in ipairs(libnames) do
+        table.insert(args, libname)
+    end
+    table.insert(args, driver.LUA_SOURCE_PATH .. "/liblua.a")
+    table.insert(args, "-ldl")
+    table.insert(args, "-lm")
     if link then
         local libs = util.split_string(link, ",")
         for _, lib in ipairs(libs) do
@@ -135,6 +283,9 @@ function driver.compile(modname, ast, sourcef, link)
         end
     end
     local cmd = table.concat(args, " ")
+    if verbose then
+        print(cmd)
+    end
     return os.execute(cmd)
 end
 

--- a/titan-compiler/driver.lua
+++ b/titan-compiler/driver.lua
@@ -122,7 +122,7 @@ end
 
 function driver.compile(modname, ast, sourcef, link, is_static, verbose)
     sourcef = sourcef or modname:gsub("[.]", "/") .. ".titan"
-    local code = coder.generate(modname, ast)
+    local code = coder.generate(modname, ast, not is_static)
     code = pretty.reindent_c(code)
     local filename = sourcef:gsub("[.]titan$", "") .. ".c"
 

--- a/titanc
+++ b/titanc
@@ -9,6 +9,7 @@ local driver = require 'titan-compiler.driver'
 local p = argparse('titan', 'Titan compiler')
 p:argument('module', 'Names of the modules to compile.'):args("+")
 p:flag('--print-ast', 'Print the AST.')
+p:flag('-v --verbose', 'Be verbose about compiler invocations.')
 p:option('-u --lua', 'Path to Lua source tree (to find Lua headers, defaults to "lua/src").')
 p:option('-t --tree', 'Root of the source tree, used for looking for source modules (defaults to ".").')
 p:option('-l --link', 'Comma-separated list of additional libraries to link into module.')
@@ -24,6 +25,7 @@ driver.TITAN_SOURCE_PATH = args.tree or driver.TITAN_SOURCE_PATH
 driver.LUA_SOURCE_PATH = args.lua or driver.LUA_SOURCE_PATH
 
 local errors = {}
+local main_module = nil
 
 for _, modname in ipairs(args.module) do
     local ok, errs = checker.checkimport(modname, driver.defaultloader)
@@ -32,6 +34,13 @@ for _, modname in ipairs(args.module) do
     else
         if #errs > 0 then table.insert(errors, table.concat(errs, "\n")) end
         local ast = driver.imported[modname].ast
+        if checker.has_main(ast) then
+            if main_module then
+                table.insert(errors, modname .. ": multiple main functions found (already declared in " .. main_module ..")")
+            else
+                main_module = modname
+            end
+        end
         if args.print_ast and ast then
             print(parser.pretty_print_ast(ast))
         end
@@ -40,9 +49,18 @@ end
 
 if #errors > 0 then exit(table.concat(errors, "\n")) end
 
+local libnames = {}
 for name, mod in pairs(driver.imported) do
-    local ok, err = driver.compile_module(name, mod, args.link)
-    if not ok then table.insert(errors, err) end
+    local ok, err, libname = driver.compile_module(name, mod, args.link, main_module ~= nil, args.verbose)
+    if not ok then
+        table.insert(errors, err)
+    else
+        table.insert(libnames, libname)
+    end
+end
+
+if main_module then
+    driver.compile_program(main_module, libnames, args.link, args.verbose)
 end
 
 if #errors > 0 then exit(table.concat(errors, "\n")) end


### PR DESCRIPTION
This PR adds support for compiling stand-alone executables.

If a module contains a `main` function with signature `function({string}):integer`,
that is the main entry point of the program. The input argument is an array
of strings containing the command-line arguments, and the integer return value
is the exit code of the program.

Only one of the modules given to `titanc` may contain a `main` function.

When compiling a program as a single executable, `titanc` does not use dynamic linking to resolve references in imports. Instead, it generates simple `extern` declarations that are resolved in the linking step.

The `examples.sdl_demo` example is modified to demonstrate this, moving the helper function into a separate module.

Additionally, this adds a `-v`/`--verbose` flag to `titanc`, which makes it display the C compiler invocations.