### PR TITLE
Builtin functions

### DIFF
--- a/doc/manual.md
+++ b/doc/manual.md
@@ -400,6 +400,58 @@ Casts from `float` to `integer` fail if it is not an integral value, and if
 this value is outside the allowable range for integers. Casts from `value`
 fail if the value does not have the target type, or cannot be converted to it.
 
+## The standard library
+
+### Basic functions
+
+You can call these functions directly from anywhere in a Titan module,
+without needing to import anything.
+
+#### assert(v: value, msg: string): string
+
+Returns `v` if it is truthy, otherwise throws an error with message `msg`.
+
+#### dofile(filename: string, ...: value): { value }
+
+Executes the Lua chunk inside the file named `filename`, passing any extra
+arguments (you can access these arguments inside the Lua code with `...`).
+Returns an array containing all the values that the Lua chunk returned.
+
+The Lua code can load (using `require`) any Titan module that is part of
+a Titan application, if you are running in the context of an application.
+
+#### dostring(chunk: string, ...: value): { value }
+
+Executes the Lua chunk inside `chunk`, passing any extra
+arguments (you can access these arguments inside the Lua code with `...`).
+Returns an array containing all the values that the Lua chunk returned.
+
+The Lua code can load (using `require`) any Titan module that is part of
+a Titan application, if you are running in the context of an application.
+
+#### error(msg: string)
+
+Throws an error with error message `msg`.
+
+#### print(...: value)
+
+Prints its arguments to the standard output, separated by tabs and ending in a newline
+(`print()` prints just a newline).
+
+#### tostring(v: value): string
+
+Returns the string representation for the Titan value `v`.
+
+#### tofloat(s: string): float
+
+If `s` has a numeric literal returns the corresponding number as a floating
+point value, otherwise returns `0.0`.
+
+#### tointeger(s: string): integer
+
+If `s` has an integer literal or an integral floating point literal
+returns the corresponding integer value, otherwise returns `0`.
+
 ## The Complete Syntax of Titan
 
 Here is the complete syntax of Titan in extended BNF. As usual in extended BNF, {A} means 0 or more As, and \[A\] means an optional A.

--- a/doc/manual.md
+++ b/doc/manual.md
@@ -281,7 +281,7 @@ An `import` statement references another module and lets the current
 module use its exported module variables and functions. Its syntax
 is:
 
-    local <localname> = import "<modname>"
+    [local <localname> =] import "<modname>"
 
 The module name `<modname>` is a name like `foo`, `foo.bar`, or `foo.bar.baz`.
 The Titan compiler translates a module name into a file name by converting
@@ -289,6 +289,9 @@ all dots to path separators, and then appending `.so`, for binary modules, or
 `.titan`, for source modules, so the above three
 modules will correspond to `foo.{so|titan}`, `foo/bar.{so|titan}`, and `foo/bar/baz.{so|titan}`.
 The Titan compiler will recompile the module if its source is newer than its binary.
+
+If the `<localname>` is not given, Titan will use the last name of
+the module (`foo` for all of `foo`, `bar.foo`, or `baz.bar.foo`, for example).
 
 Binary modules are looked up in the *runtime search path*, a semicolon-separated list
 of paths that defaults to `.;/usr/local/lib/titan/0.5`, but can be overriden with a
@@ -323,11 +326,14 @@ as call the exported function `bar`.
 A `foreign import` statement loads a C header file, and imports all its
 function and type definitions. Its syntax is:
 
-    local <localname> = foreign import "<headername>"
+    [local <localname> =] foreign import "<headername>"
 
 The string containing the `<headername>` argument may be a relative or
 absolute pathname to a C header file. When a relative pathname is given,
 the Titan compiler will search in standard C header paths.
+
+If the `<localname>` is not given, Titan will use the name of the header
+file without the path part (`foo` for `path/foo.h`, for example).
 
 Due to the flat namespace of C functions and types, all types and functions
 imported via foreign imports share a single namespace in Titan as well.
@@ -340,8 +346,8 @@ many headers will import the same system headers.
 
 For example, if one loads two header files like this
 
-    local foo = foreign import "foo.h"
-    local bar = foreign import "bar.h"
+    foreign import "foo.h"
+    foreign import "bar.h"
 
 and both `foo.h` and `bar.h` happen to include (directly or indirectly) the
 system header `stdio.h`, this means that both `foo.printf` and `bar.printf`
@@ -456,7 +462,7 @@ returns the corresponding integer value, otherwise returns `0`.
 
 Here is the complete syntax of Titan in extended BNF. As usual in extended BNF, {A} means 0 or more As, and \[A\] means an optional A.
 
-    program ::= {tlfunc | tlvar | tlrecord | tlimport | tlforeignimport}
+    program ::= {tlfunc | tlvar | tlrecord | tlimport | tlforeignimport | tlbuiltin}
 
     tlfunc ::= [local] function Name '(' [parlist] ')'  ':' type block end
 
@@ -464,11 +470,15 @@ Here is the complete syntax of Titan in extended BNF. As usual in extended BNF, 
 
     tlrecord ::= record Name recordfields end
 
-    tlimport ::= local Name '=' import LiteralString
+    tlimport ::= [local Name '='] import LiteralString
 
-    tlforeignimport ::= local Name '=' foreign import LiteralString
+    tlforeignimport ::= [local Name '='] foreign import LiteralString
 
-    parlist ::= Name ':' type {',' Name ':' type}
+    tlbuiltin ::= builtin function Name '(' [parlist] ')'  ':' type
+
+    param ::= Name ':' type | '...' ':' type
+
+    parlist ::= param {',' param}
 
     type ::= value | integer | float | boolean | string | array | map
 

--- a/doc/manual.md
+++ b/doc/manual.md
@@ -462,7 +462,7 @@ returns the corresponding integer value, otherwise returns `0`.
 
 Here is the complete syntax of Titan in extended BNF. As usual in extended BNF, {A} means 0 or more As, and \[A\] means an optional A.
 
-    program ::= {tlfunc | tlvar | tlrecord | tlimport | tlforeignimport | tlbuiltin}
+    program ::= {tlfunc | tlvar | tlrecord | tlimport | tlforeignimport | tlforeignfunc}
 
     tlfunc ::= [local] function Name '(' [parlist] ')'  ':' type block end
 
@@ -474,7 +474,7 @@ Here is the complete syntax of Titan in extended BNF. As usual in extended BNF, 
 
     tlforeignimport ::= [local Name '='] foreign import LiteralString
 
-    tlbuiltin ::= builtin function Name '(' [parlist] ')'  ':' type
+    tlforeignfunc ::= foreign function Name '(' [parlist] ')'  ':' type
 
     param ::= Name ':' type | '...' ':' type
 

--- a/spec/checker_spec.lua
+++ b/spec/checker_spec.lua
@@ -1629,25 +1629,31 @@ describe("Titan type checker", function()
     end)
 
     it("catches use of function as first-class value", function ()
-        local code = [[
+        assert_type_error("access a function", [[
             function foo(): integer
                 return foo
             end
-        ]]
-        local ok, err = run_checker(code)
-        assert.falsy(ok)
-        assert.match("access a function", err)
+        ]])
+        assert_type_error("access a function", [[
+            builtin function bar()
+            function foo(): integer
+                return bar
+            end
+        ]])
     end)
 
     it("catches assignment to function", function ()
-        local code = [[
+        assert_type_error("assign to a function",[[
             function foo(): integer
                 foo = 2
             end
-        ]]
-        local ok, err = run_checker(code)
-        assert.falsy(ok)
-        assert.match("assign to a function", err)
+        ]])
+        assert_type_error("assign to a function",[[
+            builtin function bar()
+            function foo(): integer
+                bar = 2
+            end
+        ]])
     end)
 
     it("catches use of external function as first-class value", function ()
@@ -1669,12 +1675,46 @@ describe("Titan type checker", function()
         assert.match("access a function", err)
     end)
 
+    it("catches use of external builtin function as first-class value", function ()
+        local modules = {
+            foo = [[
+                builtin function foo()
+            ]],
+            bar = [[
+                local foo = import "foo"
+                function bar(): integer
+                    return foo.foo
+                end
+            ]]
+        }
+        local ok, err, mods = run_checker_modules(modules, "bar")
+        assert.falsy(ok)
+        assert.match("access a function", err)
+    end)
+
     it("catches assignment to external function", function ()
         local modules = {
             foo = [[
                 a: integer = 1
                 function foo()
                 end
+            ]],
+            bar = [[
+                local foo = import "foo"
+                function bar(): integer
+                    foo.foo = 2
+                end
+            ]]
+        }
+        local ok, err, mods = run_checker_modules(modules, "bar")
+        assert.falsy(ok)
+        assert.match("assign to a function", err)
+    end)
+
+    it("catches assignment to external builtin function", function ()
+        local modules = {
+            foo = [[
+                builtin function foo()
             ]],
             bar = [[
                 local foo = import "foo"
@@ -1907,12 +1947,63 @@ describe("Titan type checker", function()
             function h()
                 f(20, (g()))
             end
+        ]], args = 2, params = 3 },{ code = [[
+            function g(): (integer, integer)
+                return 20, 30
+            end
+            builtin function f(x: integer, y: integer, z: integer)
+            function h()
+                f(g())
+            end
+        ]], args = 2, params = 3 }, { code = [[
+            function g(): (integer, integer)
+                return 20, 30
+            end
+            builtin function f(x: integer, y: integer, z: integer)
+            function h()
+                f(20, 30, g())
+            end
+        ]], args = 4, params = 3 }, { code = [[
+            function g(): (integer, integer)
+                return 20, 30
+            end
+            builtin function f(x: integer, y: integer, z: integer)
+            function h()
+                f(20, (g()))
+            end
         ]], args = 2, params = 3 }}
         for _, c in ipairs(cases) do
             local ok, err = run_checker(c.code)
             assert.falsy(ok)
             assert.match("function 'f' called with " .. c.args .. " arguments but expects " .. c.params, err)
         end
+    end)
+
+    it("vararg builtins and functions", function ()
+        assert_type_check([[
+            builtin function f(a: string, ...: float)
+            function g()
+                f('foo', 1, 2.5)
+            end
+        ]])
+        assert_type_error("only the last parameter", [[
+            builtin function f(...: float, a: string)
+        ]])
+        assert_type_error("only the last parameter", [[
+            function f(...: float, a: string)
+            end
+        ]])
+        assert_type_error("only the last parameter", [[
+            record R end
+            function R:f(...: float, a: string)
+            end
+        ]])
+        assert_type_error("expected float but found string", [[
+            builtin function f(a: string, ...: float)
+            function g()
+                f('foo', 1, 'bar')
+            end
+        ]])
     end)
 end)
 

--- a/spec/checker_spec.lua
+++ b/spec/checker_spec.lua
@@ -1635,7 +1635,7 @@ describe("Titan type checker", function()
             end
         ]])
         assert_type_error("access a function", [[
-            builtin function bar()
+            foreign function bar()
             function foo(): integer
                 return bar
             end
@@ -1649,7 +1649,7 @@ describe("Titan type checker", function()
             end
         ]])
         assert_type_error("assign to a function",[[
-            builtin function bar()
+            foreign function bar()
             function foo(): integer
                 bar = 2
             end
@@ -1675,10 +1675,10 @@ describe("Titan type checker", function()
         assert.match("access a function", err)
     end)
 
-    it("catches use of external builtin function as first-class value", function ()
+    it("catches use of external foreign function as first-class value", function ()
         local modules = {
             foo = [[
-                builtin function foo()
+                foreign function foo()
             ]],
             bar = [[
                 local foo = import "foo"
@@ -1711,10 +1711,10 @@ describe("Titan type checker", function()
         assert.match("assign to a function", err)
     end)
 
-    it("catches assignment to external builtin function", function ()
+    it("catches assignment to external foreign function", function ()
         local modules = {
             foo = [[
-                builtin function foo()
+                foreign function foo()
             ]],
             bar = [[
                 local foo = import "foo"
@@ -1951,7 +1951,7 @@ describe("Titan type checker", function()
             function g(): (integer, integer)
                 return 20, 30
             end
-            builtin function f(x: integer, y: integer, z: integer)
+            foreign function f(x: integer, y: integer, z: integer)
             function h()
                 f(g())
             end
@@ -1959,7 +1959,7 @@ describe("Titan type checker", function()
             function g(): (integer, integer)
                 return 20, 30
             end
-            builtin function f(x: integer, y: integer, z: integer)
+            foreign function f(x: integer, y: integer, z: integer)
             function h()
                 f(20, 30, g())
             end
@@ -1967,7 +1967,7 @@ describe("Titan type checker", function()
             function g(): (integer, integer)
                 return 20, 30
             end
-            builtin function f(x: integer, y: integer, z: integer)
+            foreign function f(x: integer, y: integer, z: integer)
             function h()
                 f(20, (g()))
             end
@@ -1979,15 +1979,15 @@ describe("Titan type checker", function()
         end
     end)
 
-    it("vararg builtins and functions", function ()
+    it("vararg foreigns and functions", function ()
         assert_type_check([[
-            builtin function f(a: string, ...: float)
+            foreign function f(a: string, ...: float)
             function g()
                 f('foo', 1, 2.5)
             end
         ]])
         assert_type_error("only the last parameter", [[
-            builtin function f(...: float, a: string)
+            foreign function f(...: float, a: string)
         ]])
         assert_type_error("only the last parameter", [[
             function f(...: float, a: string)
@@ -1999,7 +1999,7 @@ describe("Titan type checker", function()
             end
         ]])
         assert_type_error("expected float but found string", [[
-            builtin function f(a: string, ...: float)
+            foreign function f(a: string, ...: float)
             function g()
                 f('foo', 1, 'bar')
             end

--- a/spec/coder_spec.lua
+++ b/spec/coder_spec.lua
@@ -2435,29 +2435,6 @@ describe("Titan code generator", function()
                 assert(test.f('foo') == 0)
             ]])
         end)
-
-        it("calls foreign from another module", function ()
-            local modules = {
-                string = [[
-                    foreign function byte(s: string, i: integer): integer
-                ]],
-                bar = [[
-                    import "string"
-                    function main(args: {string}): integer
-                        if string.byte('foo', 1) == 102 then
-                            return 0
-                        else
-                            return 1
-                        end
-                    end
-                ]]
-            }
-            local ok, err = generate_modules(modules, "bar", true)
-            assert.truthy(ok, err)
-            local ok, err, status = call_app("./bar")
-            assert.truthy(ok, err)
-            assert.equal(0, status)
-        end)
     end)
 
 end)

--- a/spec/coder_spec.lua
+++ b/spec/coder_spec.lua
@@ -2435,6 +2435,29 @@ describe("Titan code generator", function()
                 assert(test.f('foo') == 0)
             ]])
         end)
+
+        it("calls builtin from another module", function ()
+            local modules = {
+                string = [[
+                    builtin function byte(s: string, i: integer): integer
+                ]],
+                bar = [[
+                    local string = import "string"
+                    function main(args: {string}): integer
+                        if string.byte('foo', 1) == 102 then
+                            return 0
+                        else
+                            return 1
+                        end
+                    end
+                ]]
+            }
+            local ok, err = generate_modules(modules, "bar", true)
+            assert.truthy(ok, err)
+            local ok, err, status = call_app("./bar")
+            assert.truthy(ok, err)
+            assert.equal(0, status)
+        end)
     end)
 
 end)

--- a/spec/coder_spec.lua
+++ b/spec/coder_spec.lua
@@ -2326,6 +2326,28 @@ describe("Titan code generator", function()
             assert.equal(0, status)
         end)
 
+        it("correctly uses module local variables in application", function ()
+            local modules = {
+                foo = [[
+                    local xs: {integer} = {}
+                    function resetxs()
+                        xs = {}
+                    end
+                ]],
+                bar = [[
+                    local foo = import "foo"
+                    function main(args: {string}): integer
+                        foo.resetxs()
+                        return 42
+                    end
+                ]]
+            }
+            local ok, err = generate_modules(modules, "bar", true)
+            assert.truthy(ok, err)
+            local ok, err, status = call_app("./bar")
+            assert.truthy(ok, err)
+            assert.equal(42, status)
+        end)
     end)
 
     describe("#foreigns", function()

--- a/spec/coder_spec.lua
+++ b/spec/coder_spec.lua
@@ -2442,7 +2442,7 @@ describe("Titan code generator", function()
                     builtin function byte(s: string, i: integer): integer
                 ]],
                 bar = [[
-                    local string = import "string"
+                    import "string"
                     function main(args: {string}): integer
                         if string.byte('foo', 1) == 102 then
                             return 0

--- a/spec/coder_spec.lua
+++ b/spec/coder_spec.lua
@@ -2328,7 +2328,7 @@ describe("Titan code generator", function()
 
     end)
 
-    describe("#primitives", function()
+    describe("#builtins", function()
         it("call print", function ()
             run_coder_app([[
             ]], [[

--- a/spec/coder_spec.lua
+++ b/spec/coder_spec.lua
@@ -2328,7 +2328,7 @@ describe("Titan code generator", function()
 
     end)
 
-    describe("#builtins", function()
+    describe("#foreigns", function()
         it("call print", function ()
             run_coder_app([[
             ]], [[
@@ -2436,10 +2436,10 @@ describe("Titan code generator", function()
             ]])
         end)
 
-        it("calls builtin from another module", function ()
+        it("calls foreign from another module", function ()
             local modules = {
                 string = [[
-                    builtin function byte(s: string, i: integer): integer
+                    foreign function byte(s: string, i: integer): integer
                 ]],
                 bar = [[
                     import "string"

--- a/spec/parser_spec.lua
+++ b/spec/parser_spec.lua
@@ -702,6 +702,27 @@ describe("Titan parser", function()
         assert_program_ast([[ local foo = import "module.foo" ]], {
             { _tag = "Ast.TopLevelImport", localname = "foo", modname = "module.foo" },
         })
+        assert_program_ast([[ import "module.foo" ]], {
+            { _tag = "Ast.TopLevelImport", localname = "foo", modname = "module.foo" },
+        })
+        assert_program_ast([[ local foo = import "foo" ]], {
+            { _tag = "Ast.TopLevelImport", localname = "foo", modname = "foo" },
+        })
+        assert_program_ast([[ import "foo" ]], {
+            { _tag = "Ast.TopLevelImport", localname = "foo", modname = "foo" },
+        })
+        assert_program_ast([[ local foo = foreign import "module/foo.h" ]], {
+            { _tag = "Ast.TopLevelForeignImport", localname = "foo", headername = "module/foo.h" },
+        })
+        assert_program_ast([[ local foo = foreign import "foo.h" ]], {
+            { _tag = "Ast.TopLevelForeignImport", localname = "foo", headername = "foo.h" },
+        })
+        assert_program_ast([[ foreign import "module/foo.h" ]], {
+            { _tag = "Ast.TopLevelForeignImport", localname = "foo", headername = "module/foo.h" },
+        })
+        assert_program_ast([[ foreign import "foo.h" ]], {
+            { _tag = "Ast.TopLevelForeignImport", localname = "foo", headername = "foo.h" },
+        })
     end)
 
     it("can parse multiple assignment", function ()

--- a/spec/parser_spec.lua
+++ b/spec/parser_spec.lua
@@ -1162,5 +1162,30 @@ describe("Titan parser", function()
         assert_expression_syntax_error([[ y{42,,} ]], "ExpFieldList")
 
         assert_expression_syntax_error([[ foo as ]], "CastMissingType")
+
+        assert_program_syntax_error([[
+            builtin funtion foo (a:int, ) : int
+        ]], "BuiltinFunc")
+
+        assert_program_ast([[
+            builtin function print(...: value)
+            builtin function assert(val: value, msg: string): value
+            builtin function dofile(fname: string, ...: value): {value}
+            builtin function dostring(fname: string, ...: value): {value}
+            builtin function error(msg: string)
+            builtin function tostring(val: value): string
+            builtin function tofloat(val: string): float
+            builtin function tointeger(val: string): integer
+        ]], {
+            { _tag = "Ast.TopLevelBuiltin", name = "print", params = { {_tag = "Ast.Vararg"} }},
+            { _tag = "Ast.TopLevelBuiltin", name = "assert" },
+            { _tag = "Ast.TopLevelBuiltin", name = "dofile", params = { {_tag = "Ast.Decl"}, {_tag = "Ast.Vararg"} },
+                rettypes = { {_tag = "Ast.TypeArray"} } },
+            { _tag = "Ast.TopLevelBuiltin", name = "dostring" },
+            { _tag = "Ast.TopLevelBuiltin", name = "error" },
+            { _tag = "Ast.TopLevelBuiltin", name = "tostring" },
+            { _tag = "Ast.TopLevelBuiltin", name = "tofloat" },
+            { _tag = "Ast.TopLevelBuiltin", name = "tointeger" },
+        })
     end)
 end)

--- a/spec/parser_spec.lua
+++ b/spec/parser_spec.lua
@@ -1185,28 +1185,28 @@ describe("Titan parser", function()
         assert_expression_syntax_error([[ foo as ]], "CastMissingType")
 
         assert_program_syntax_error([[
-            builtin funtion foo (a:int, ) : int
-        ]], "BuiltinFunc")
+            foreign funtion foo (a:int, ) : int
+        ]], "ForeignFunc")
 
         assert_program_ast([[
-            builtin function print(...: value)
-            builtin function assert(val: value, msg: string): value
-            builtin function dofile(fname: string, ...: value): {value}
-            builtin function dostring(fname: string, ...: value): {value}
-            builtin function error(msg: string)
-            builtin function tostring(val: value): string
-            builtin function tofloat(val: string): float
-            builtin function tointeger(val: string): integer
+            foreign function print(...: value)
+            foreign function assert(val: value, msg: string): value
+            foreign function dofile(fname: string, ...: value): {value}
+            foreign function dostring(fname: string, ...: value): {value}
+            foreign function error(msg: string)
+            foreign function tostring(val: value): string
+            foreign function tofloat(val: string): float
+            foreign function tointeger(val: string): integer
         ]], {
-            { _tag = "Ast.TopLevelBuiltin", name = "print", params = { {_tag = "Ast.Vararg"} }},
-            { _tag = "Ast.TopLevelBuiltin", name = "assert" },
-            { _tag = "Ast.TopLevelBuiltin", name = "dofile", params = { {_tag = "Ast.Decl"}, {_tag = "Ast.Vararg"} },
+            { _tag = "Ast.TopLevelForeignFunc", name = "print", params = { {_tag = "Ast.Vararg"} }},
+            { _tag = "Ast.TopLevelForeignFunc", name = "assert" },
+            { _tag = "Ast.TopLevelForeignFunc", name = "dofile", params = { {_tag = "Ast.Decl"}, {_tag = "Ast.Vararg"} },
                 rettypes = { {_tag = "Ast.TypeArray"} } },
-            { _tag = "Ast.TopLevelBuiltin", name = "dostring" },
-            { _tag = "Ast.TopLevelBuiltin", name = "error" },
-            { _tag = "Ast.TopLevelBuiltin", name = "tostring" },
-            { _tag = "Ast.TopLevelBuiltin", name = "tofloat" },
-            { _tag = "Ast.TopLevelBuiltin", name = "tointeger" },
+            { _tag = "Ast.TopLevelForeignFunc", name = "dostring" },
+            { _tag = "Ast.TopLevelForeignFunc", name = "error" },
+            { _tag = "Ast.TopLevelForeignFunc", name = "tostring" },
+            { _tag = "Ast.TopLevelForeignFunc", name = "tofloat" },
+            { _tag = "Ast.TopLevelForeignFunc", name = "tointeger" },
         })
     end)
 end)

--- a/spec/parser_spec.lua
+++ b/spec/parser_spec.lua
@@ -1184,29 +1184,5 @@ describe("Titan parser", function()
 
         assert_expression_syntax_error([[ foo as ]], "CastMissingType")
 
-        assert_program_syntax_error([[
-            foreign funtion foo (a:int, ) : int
-        ]], "ForeignFunc")
-
-        assert_program_ast([[
-            foreign function print(...: value)
-            foreign function assert(val: value, msg: string): value
-            foreign function dofile(fname: string, ...: value): {value}
-            foreign function dostring(fname: string, ...: value): {value}
-            foreign function error(msg: string)
-            foreign function tostring(val: value): string
-            foreign function tofloat(val: string): float
-            foreign function tointeger(val: string): integer
-        ]], {
-            { _tag = "Ast.TopLevelForeignFunc", name = "print", params = { {_tag = "Ast.Vararg"} }},
-            { _tag = "Ast.TopLevelForeignFunc", name = "assert" },
-            { _tag = "Ast.TopLevelForeignFunc", name = "dofile", params = { {_tag = "Ast.Decl"}, {_tag = "Ast.Vararg"} },
-                rettypes = { {_tag = "Ast.TypeArray"} } },
-            { _tag = "Ast.TopLevelForeignFunc", name = "dostring" },
-            { _tag = "Ast.TopLevelForeignFunc", name = "error" },
-            { _tag = "Ast.TopLevelForeignFunc", name = "tostring" },
-            { _tag = "Ast.TopLevelForeignFunc", name = "tofloat" },
-            { _tag = "Ast.TopLevelForeignFunc", name = "tointeger" },
-        })
     end)
 end)

--- a/spec/parser_spec.lua
+++ b/spec/parser_spec.lua
@@ -870,21 +870,33 @@ describe("Titan parser", function()
         assert_statements_syntax_error([[ (x) = 42 ]], "ExpAssign")
     end)
 
-    it("does not allow identifiers that are type names", function()
-        assert_program_syntax_error([[
+    it("allows identifiers that are type names only outside type context", function()
+        assert_parses_successfuly([[
             function integer()
             end
-        ]], "NameFunc")
+        ]])
 
-        assert_program_syntax_error([[
+        assert_parses_successfuly([[
             function f()
                 local integer: integer = 10
             end
-        ]], "DeclLocal")
+        ]])
+
+        assert_program_syntax_error([[
+            function f()
+                local integer: foo.integer = 10
+            end
+        ]], "QualName")
+
+        assert_parses_successfuly([[
+            function f()
+                local integer: integer.foo = 10
+            end
+        ]])
     end)
 
-    it("doesn't allow using a primitive type as a record", function()
-        assert_expression_syntax_error("integer.new(10)", "ExpAssign")
+    it("allows using a primitive type as a module name", function()
+        assert_expression_ast("integer.new(10)", {})
     end)
 
     it("uses specific error labels for some errors", function()

--- a/titan-compiler/ast.lua
+++ b/titan-compiler/ast.lua
@@ -77,7 +77,7 @@ return typedecl("Ast", {
         Field           = {"loc", "name", "exp"},
     },
 
-    Primitive = {
-        PrimitiveFunction = { "name", "_type" }
+    Builtin = {
+        BuiltinFunc = { "name", "_type" }
     },
 })

--- a/titan-compiler/ast.lua
+++ b/titan-compiler/ast.lua
@@ -76,4 +76,8 @@ return typedecl("Ast", {
     Field = {
         Field           = {"loc", "name", "exp"},
     },
+
+    Primitive = {
+        PrimitiveFunction = { "name", "_type" }
+    },
 })

--- a/titan-compiler/ast.lua
+++ b/titan-compiler/ast.lua
@@ -23,7 +23,7 @@ return typedecl("Ast", {
         TopLevelRecord  = {"loc", "name", "fields"},
         TopLevelImport  = {"loc", "localname", "modname"},
         TopLevelForeignImport = {"loc", "localname", "headername"},
-        TopLevelBuiltin = {"loc", "name", "params", "rettypes"},
+        TopLevelForeignFunc = {"loc", "name", "params", "rettypes"},
     },
 
     Decl = {

--- a/titan-compiler/ast.lua
+++ b/titan-compiler/ast.lua
@@ -23,10 +23,12 @@ return typedecl("Ast", {
         TopLevelRecord  = {"loc", "name", "fields"},
         TopLevelImport  = {"loc", "localname", "modname"},
         TopLevelForeignImport = {"loc", "localname", "headername"},
+        TopLevelBuiltin = {"loc", "name", "params", "rettypes"},
     },
 
     Decl = {
         Decl = {"loc", "name", "type"},
+        Vararg = {"loc", "type"}
     },
 
     Stat = {
@@ -75,9 +77,5 @@ return typedecl("Ast", {
 
     Field = {
         Field           = {"loc", "name", "exp"},
-    },
-
-    Builtin = {
-        BuiltinFunc = { "name", "_type" }
     },
 })

--- a/titan-compiler/checker.lua
+++ b/titan-compiler/checker.lua
@@ -1588,7 +1588,7 @@ local function makemoduletype(modname, modast)
 end
 
 local function add_foreigns(st)
-    local nodes = parser.parse("foreign.titan", [[
+    local nodes, err, foo = parser.parse_foreign([[
         foreign function print(...: value)
         foreign function assert(val: value, msg: string): value
         foreign function dofile(fname: string, ...: value): {value}

--- a/titan-compiler/checker.lua
+++ b/titan-compiler/checker.lua
@@ -1033,7 +1033,7 @@ checkexp = util.make_visitor({
             local ftype = node.exp._type
             local fname = expname(node.exp)
             local var = node.exp.var
-            if not (var and var._decl and (var._decl._tag == "Ast.PrimitiveFunction" or
+            if not (var and var._decl and (var._decl._tag == "Ast.BuiltinFunc" or
               var._decl._tag == "Ast.TopLevelFunc" or
               var._decl._tag == "Type.ModuleMember" or
               var._decl._tag == "Type.StaticMethod")) then
@@ -1533,29 +1533,29 @@ local function makemoduletype(modname, modast)
     return types.Module(modname, members)
 end
 
-local function add_primitives(st)
+local function add_builtins(st)
     st:add_symbol("print",
-        ast.PrimitiveFunction("print", types.Function({}, { types.Nil() }, types.Value())))
+        ast.BuiltinFunc("print", types.Function({}, { types.Nil() }, types.Value())))
     st:add_symbol("assert",
-        ast.PrimitiveFunction("assert",
+        ast.BuiltinFunc("assert",
             types.Function({ types.Value(), types.String() }, { types.Value() }, false)))
     st:add_symbol("dofile",
-        ast.PrimitiveFunction("dofile",
+        ast.BuiltinFunc("dofile",
             types.Function({ types.String() }, { types.Array(types.Value()) }, types.Value())))
     st:add_symbol("error",
-        ast.PrimitiveFunction("error",
+        ast.BuiltinFunc("error",
             types.Function({ types.String() }, { types.Nil() }, false)))
     st:add_symbol("dostring",
-        ast.PrimitiveFunction("dostring",
+        ast.BuiltinFunc("dostring",
             types.Function({ types.String() }, { types.Array(types.Value()) }, types.Value())))
     st:add_symbol("tostring",
-        ast.PrimitiveFunction("tostring",
+        ast.BuiltinFunc("tostring",
             types.Function({ types.Value() }, { types.String() }, false)))
     st:add_symbol("tofloat",
-        ast.PrimitiveFunction("tofloat",
+        ast.BuiltinFunc("tofloat",
             types.Function({ types.String() }, { types.Float() }, false)))
     st:add_symbol("tointeger",
-        ast.PrimitiveFunction("tointeger",
+        ast.BuiltinFunc("tointeger",
             types.Function({ types.String() }, { types.Integer() }, false)))
 end
 
@@ -1575,7 +1575,7 @@ function checker.check(modname, ast, subject, filename, loader)
         return nil, "you must pass a loader to import modules"
     end
     local st = symtab.new(modname)
-    add_primitives(st)
+    add_builtins(st)
     local errors = {subject = subject, filename = filename}
     checktoplevel(ast, st, errors, loader)
     checkbodies(ast, st, errors)

--- a/titan-compiler/coder.lua
+++ b/titan-compiler/coder.lua
@@ -1064,6 +1064,7 @@ local function codecall(ctx, node)
     local fname
     local fnode = node.exp.var
     local modarg = "_mod"
+    local ftype = fnode._type
     if node.args._tag == "Ast.ArgsFunc" then
         if fnode._tag == "Ast.VarName" then
             if fnode._decl._tag == "Ast.PrimitiveFunction" then
@@ -1112,6 +1113,7 @@ local function codecall(ctx, node)
     else
         assert(node.args._tag == "Ast.ArgsMethod")
         local mtype = node._method
+        ftype = mtype
         fname = method_name(mtype)
         local mod, record = mtype.fqtn:match("^(.*)%.(%a+)$")
         if mod ~= ctx.module then
@@ -1134,7 +1136,7 @@ local function codecall(ctx, node)
         table.insert(caexps, modarg)
         table.insert(caexps, cexp)
     end
-    for i = 1, #fnode._type.params do
+    for i = 1, #ftype.params do
         local arg = node.args.args[i]
         local cstat, cexp = codeexp(ctx, arg)
         table.insert(castats, cstat)
@@ -1150,10 +1152,10 @@ local function codecall(ctx, node)
         table.insert(caexps, "&" .. tmpname)
         retslots[i] = tmpslot
     end
-    if type(fnode._type.vararg) == "table" then
-        table.insert(caexps, c_integer_literal(#node.args.args - #fnode._type.params))
+    if type(ftype.vararg) == "table" then
+        table.insert(caexps, c_integer_literal(#node.args.args - #ftype.params))
     end
-    for i = #fnode._type.params+1, #node.args.args do
+    for i = #ftype.params+1, #node.args.args do
         local arg = node.args.args[i]
         local cstat, cexp = codeexp(ctx, arg)
         table.insert(castats, cstat)

--- a/titan-compiler/coder.lua
+++ b/titan-compiler/coder.lua
@@ -115,7 +115,7 @@ local function func_name(modname, name)
 end
 
 local function builtin_name(name)
-    return "titan_" .. name
+    return "titan_" .. mangle_qn(name)
 end
 
 local function func_luaname(modname, name)
@@ -1067,10 +1067,10 @@ local function codecall(ctx, node)
     local ftype = fnode._type
     if node.args._tag == "Ast.ArgsFunc" then
         if fnode._tag == "Ast.VarName" then
-            if fnode._decl._tag == "Ast.BuiltinFunc" then
-                fname = builtin_name(fnode._decl.name)
+            if ftype._tag == "Type.BuiltinFunction" then
+                fname = builtin_name(ftype.name)
             else
-                assert(fnode._decl._tag == "Ast.TopLevelFunc")
+                assert(ftype._tag == "Type.Function")
                 fname = func_name(ctx.module, fnode.name)
             end
         elseif fnode._tag == "Ast.VarDot" then
@@ -1092,6 +1092,8 @@ local function codecall(ctx, node)
                         INDEX = c_integer_literal(fnode.exp.var.exp.var._decl._upvalue) -- whew!
                     })
                 end
+            elseif ftype._tag == "Type.BuiltinFunction" then
+                fname = builtin_name(ftype.name)
             else
                 assert(fnode._decl._tag == "Type.ModuleMember")
                 fname = func_name(fnode._decl.modname, fnode.name)

--- a/titan-compiler/coder.lua
+++ b/titan-compiler/coder.lua
@@ -114,7 +114,7 @@ local function func_name(modname, name)
     return modprefix(modname) .. name .. "_titan"
 end
 
-local function builtin_name(name)
+local function foreign_name(name)
     return "titan_" .. mangle_qn(name)
 end
 
@@ -1071,10 +1071,10 @@ local function codecall(ctx, node)
     local ftype = fnode._type
     if node.args._tag == "Ast.ArgsFunc" then
         if fnode._tag == "Ast.VarName" then
-            if ftype._tag == "Type.BuiltinFunction" then
-                fname = builtin_name(ftype.name)
+            if ftype._tag == "Type.ForeignFunction" then
+                fname = foreign_name(ftype.name)
                 ctx.functions[ftype.name] = {
-                    mangled = builtin_name(ftype.name),
+                    mangled = foreign_name(ftype.name),
                     type = ftype
                 }
             else
@@ -1100,10 +1100,10 @@ local function codecall(ctx, node)
                         INDEX = c_integer_literal(fnode.exp.var.exp.var._decl._upvalue) -- whew!
                     })
                 end
-            elseif ftype._tag == "Type.BuiltinFunction" then
-                fname = builtin_name(ftype.name)
+            elseif ftype._tag == "Type.ForeignFunction" then
+                fname = foreign_name(ftype.name)
                 ctx.functions[ftype.name] = {
-                    mangled = builtin_name(ftype.name),
+                    mangled = foreign_name(ftype.name),
                     type = ftype
                 }
             else
@@ -2558,7 +2558,7 @@ local function init_data_from_other_modules(tlcontext, includes, loadmods, initm
 
     for name, func in pairs(tlcontext.functions) do
         local fname = func.mangled
-        if func.type._tag == "Type.BuiltinFunction" then
+        if func.type._tag == "Type.ForeignFunction" then
             table.insert(includes, "extern " .. function_sig(fname, func.type) .. ";")
         else
             table.insert(includes, storage_class .. " " .. function_sig(fname, func.type, is_dynamic) .. ";")

--- a/titan-compiler/coder.lua
+++ b/titan-compiler/coder.lua
@@ -114,7 +114,7 @@ local function func_name(modname, name)
     return modprefix(modname) .. name .. "_titan"
 end
 
-local function primitive_name(name)
+local function builtin_name(name)
     return "titan_" .. name
 end
 
@@ -1067,8 +1067,8 @@ local function codecall(ctx, node)
     local ftype = fnode._type
     if node.args._tag == "Ast.ArgsFunc" then
         if fnode._tag == "Ast.VarName" then
-            if fnode._decl._tag == "Ast.PrimitiveFunction" then
-                fname = primitive_name(fnode._decl.name)
+            if fnode._decl._tag == "Ast.BuiltinFunc" then
+                fname = builtin_name(fnode._decl.name)
             else
                 assert(fnode._decl._tag == "Ast.TopLevelFunc")
                 fname = func_name(ctx.module, fnode.name)

--- a/titan-compiler/lexer.lua
+++ b/titan-compiler/lexer.lua
@@ -165,8 +165,10 @@ local keywords = {
     "and", "break", "do", "else", "elseif", "end", "for", "false",
     "function", "goto", "if", "in", "local", "nil", "not", "or",
     "repeat", "return", "then", "true", "until", "while", "import",
-    "record", "as", "foreign",
+    "record", "as", "foreign"
+}
 
+local type_keywords = {
     "boolean", "integer", "float", "string", "value"
 }
 
@@ -174,13 +176,32 @@ for _, keyword in ipairs(keywords) do
     lexer[keyword:upper()] = P(keyword) * -idrest
 end
 
+for _, keyword in ipairs(type_keywords) do
+    lexer[keyword:upper()] = P(keyword) * -idrest
+end
+
 local is_keyword = {}
+local is_type_keyword = {}
+
 for _, keyword in ipairs(keywords) do
     is_keyword[keyword] = true
+    is_type_keyword[keyword] = true
+end
+
+for _, keyword in ipairs(type_keywords) do
+    is_type_keyword[keyword] = true
 end
 
 lexer.NAME = Cmt(C(possiblename), function(_, pos, s)
     if not is_keyword[s] then
+        return pos, s
+    else
+        return false
+    end
+end)
+
+lexer.TYPENAME = Cmt(C(possiblename), function(_, pos, s)
+    if not is_type_keyword[s] then
         return pos, s
     else
         return false

--- a/titan-compiler/lexer.lua
+++ b/titan-compiler/lexer.lua
@@ -165,7 +165,7 @@ local keywords = {
     "and", "break", "do", "else", "elseif", "end", "for", "false",
     "function", "goto", "if", "in", "local", "nil", "not", "or",
     "repeat", "return", "then", "true", "until", "while", "import",
-    "record", "as", "foreign", "builtin"
+    "record", "as", "foreign"
 }
 
 local type_keywords = {

--- a/titan-compiler/lexer.lua
+++ b/titan-compiler/lexer.lua
@@ -165,7 +165,7 @@ local keywords = {
     "and", "break", "do", "else", "elseif", "end", "for", "false",
     "function", "goto", "if", "in", "local", "nil", "not", "or",
     "repeat", "return", "then", "true", "until", "while", "import",
-    "record", "as", "foreign"
+    "record", "as", "foreign", "builtin"
 }
 
 local type_keywords = {

--- a/titan-compiler/parser.lua
+++ b/titan-compiler/parser.lua
@@ -235,7 +235,7 @@ local grammar = re.compile([[
                            / toplevelfunc
                            / toplevelvar
                            / toplevelrecord
-                           / toplevelbuiltin
+                           / toplevelforeign
                            / import
                            / shortimport
                            / foreign
@@ -249,9 +249,9 @@ local grammar = re.compile([[
                            LPAREN^LParPList paramlist RPAREN^RParPList
                            rettypeopt block END^EndFunc)         -> TopLevelFunc
 
-    toplevelbuiltin <- (P  BUILTIN FUNCTION^BuiltinFunc NAME^NameFunc
+    toplevelforeign <- (P  FOREIGN FUNCTION^ForeignFunc NAME^NameFunc
                            LPAREN^LParPList paramlist RPAREN^RParPList
-                           rettypeopt)                           -> TopLevelBuiltin
+                           rettypeopt)                           -> TopLevelForeignFunc
 
     toplevelvar     <- (P localopt decl ASSIGN^AssignVar
                            !(IMPORT / FOREIGN)
@@ -483,7 +483,6 @@ local grammar = re.compile([[
     IMPORT          <- %IMPORT SKIP*
     AS              <- %AS SKIP*
     FOREIGN         <- %FOREIGN SKIP*
-    BUILTIN         <- %BUILTIN SKIP*
 
     BOOLEAN         <- %BOOLEAN SKIP*
     INTEGER         <- %INTEGER SKIP*

--- a/titan-compiler/parser.lua
+++ b/titan-compiler/parser.lua
@@ -242,7 +242,7 @@ local grammar = re.compile([[
                            !(IMPORT / FOREIGN)
                            exp^ExpVarDec)                        -> TopLevelVar
 
-    toplevelrecord  <- (P  RECORD NAME^NameRecord
+    toplevelrecord  <- (P  RECORD TYPENAME^NameRecord
                            recordfields^FieldRecord
                            END^EndRecord)                        -> recorddecl
 
@@ -269,20 +269,20 @@ local grammar = re.compile([[
 
     decllist        <- {| decl (COMMA decl^DeclParList)* |}      -- produces {Decl}
 
-    simpletype      <- (P  NIL)                                  -> TypeNil
+    simpletype      <- ((P  NAME DOT TYPENAME^QualName)       -> TypeQualName
+                     / (P  TYPENAME)                             -> TypeName
+                     / (P  NIL)                                  -> TypeNil
                      / (P  BOOLEAN)                              -> TypeBoolean
                      / (P  INTEGER)                              -> TypeInteger
                      / (P  FLOAT)                                -> TypeFloat
                      / (P  STRING)                               -> TypeString
                      / (P  VALUE)                                -> TypeValue
-                     / (P  NAME DOT NAME^QualName)               -> TypeQualName
-                     / (P  NAME)                                 -> TypeName
                      / (P  LCURLY type^TypeType
                            COLON
                            type^TypeType
                            RCURLY^RCurlyType)                    -> TypeMap
                      / (P  LCURLY type^TypeType
-                           RCURLY^RCurlyType)                    -> TypeArray
+                           RCURLY^RCurlyType)                    -> TypeArray) !DOT
 
     typelist        <- ( LPAREN
                          {| (type (COMMA type^TypelistType)*)? |}
@@ -503,6 +503,7 @@ local grammar = re.compile([[
     NUMBER          <- %NUMBER SKIP*
     STRINGLIT       <- %STRINGLIT SKIP*
     NAME            <- %NAME SKIP*
+    TYPENAME        <- %TYPENAME SKIP*
 
     -- Synonyms
 

--- a/titan-compiler/parser.lua
+++ b/titan-compiler/parser.lua
@@ -249,7 +249,7 @@ local grammar = re.compile([[
                            LPAREN^LParPList paramlist RPAREN^RParPList
                            rettypeopt block END^EndFunc)         -> TopLevelFunc
 
-    toplevelforeign <- (P  FOREIGN FUNCTION^ForeignFunc NAME^NameFunc
+    toplevelforeign <- (P  FOREIGN !IMPORT FUNCTION^ForeignFunc NAME^NameFunc
                            LPAREN^LParPList paramlist RPAREN^RParPList
                            rettypeopt)                           -> TopLevelForeignFunc
 

--- a/titan-compiler/parser.lua
+++ b/titan-compiler/parser.lua
@@ -227,6 +227,7 @@ local grammar = re.compile([[
                            / toplevelfunc
                            / toplevelvar
                            / toplevelrecord
+                           / toplevelbuiltin
                            / import
                            / foreign )* |} !.
 
@@ -237,6 +238,10 @@ local grammar = re.compile([[
     toplevelfunc    <- (P  localopt FUNCTION NAME^NameFunc
                            LPAREN^LParPList paramlist RPAREN^RParPList
                            rettypeopt block END^EndFunc)         -> TopLevelFunc
+
+    toplevelbuiltin <- (P  BUILTIN FUNCTION^BuiltinFunc NAME^NameFunc
+                           LPAREN^LParPList paramlist RPAREN^RParPList
+                           rettypeopt)                           -> TopLevelBuiltin
 
     toplevelvar     <- (P localopt decl ASSIGN^AssignVar
                            !(IMPORT / FOREIGN)
@@ -264,6 +269,8 @@ local grammar = re.compile([[
 
     param           <- (P  NAME COLON^ParamSemicolon
                            type^TypeDecl)                        -> Decl
+                     / (P DOTS COLON^ParamSemicolon
+                           type^TypeDecl)                        -> Vararg
 
     decl            <- (P  NAME (COLON type^TypeDecl)? -> opt)   -> Decl
 
@@ -458,6 +465,7 @@ local grammar = re.compile([[
     IMPORT          <- %IMPORT SKIP*
     AS              <- %AS SKIP*
     FOREIGN         <- %FOREIGN SKIP*
+    BUILTIN         <- %BUILTIN SKIP*
 
     BOOLEAN         <- %BOOLEAN SKIP*
     INTEGER         <- %INTEGER SKIP*

--- a/titan-compiler/parser.lua
+++ b/titan-compiler/parser.lua
@@ -220,6 +220,14 @@ function defs.recorddecl(pos, name, fields)
            ast.TopLevelStatic(pos, name, "new", params, { ast.TypeName(pos, name) }, body)
 end
 
+function defs.shortimport(pos, name)
+    return ast.TopLevelImport(pos, name:match("(%w+)$"), name)
+end
+
+function defs.shortforeign(pos, name)
+    return ast.TopLevelForeignImport(pos, name:match("(%w+)[.]h$"), name)
+end
+
 local grammar = re.compile([[
 
     program         <-  SKIP*
@@ -229,7 +237,9 @@ local grammar = re.compile([[
                            / toplevelrecord
                            / toplevelbuiltin
                            / import
-                           / foreign )* |} !.
+                           / shortimport
+                           / foreign
+                           / shortforeign )* |} !.
 
     method          <- (P  FUNCTION NAME COLON NAME^NameMethod
                            LPAREN^LParPList paramlist RPAREN^RParPList
@@ -258,10 +268,18 @@ local grammar = re.compile([[
                           (LPAREN STRINGLIT^StringLParImport RPAREN^RParImport /
                           STRINGLIT^StringImport))               -> TopLevelImport
 
+    shortimport     <- (P !FOREIGN IMPORT
+                          (LPAREN STRINGLIT^StringLParImport RPAREN^RParImport /
+                           STRINGLIT^StringImport))              -> shortimport
+
     foreign         <- (P  LOCAL NAME^NameImport ASSIGN^AssignImport
                            FOREIGN IMPORT^ImportImport
                           (LPAREN STRINGLIT^StringLParImport RPAREN^RParImport /
                            STRINGLIT^StringImport))              -> TopLevelForeignImport
+
+    shortforeign    <- (P FOREIGN IMPORT^ImportImport
+                          (LPAREN STRINGLIT^StringLParImport RPAREN^RParImport /
+                           STRINGLIT^StringImport))              -> shortforeign
 
     rettypeopt      <- (P  (COLON rettype^TypeFunc)?)            -> rettypeopt
 

--- a/titan-compiler/syntax_errors.lua
+++ b/titan-compiler/syntax_errors.lua
@@ -169,6 +169,7 @@ local errors = {
 
     NameMethod = "Expected a method name after the colon.",
 
+    BuiltinFunc = "Expected a builtin function declaration.",
 }
 
 syntax_errors.errors = errors

--- a/titan-compiler/syntax_errors.lua
+++ b/titan-compiler/syntax_errors.lua
@@ -169,7 +169,7 @@ local errors = {
 
     NameMethod = "Expected a method name after the colon.",
 
-    BuiltinFunc = "Expected a builtin function declaration.",
+    ForeignFunc = "Expected a foreign function declaration.",
 }
 
 syntax_errors.errors = errors

--- a/titan-compiler/types.lua
+++ b/titan-compiler/types.lua
@@ -20,7 +20,7 @@ local types = typedecl("Type", {
         ModuleMember = {"modname", "name", "type"},
         ModuleVariable = {"modname", "name", "type"},
         StaticMethod = {"fqtn", "name", "params", "rettypes"},
-        BuiltinFunction = {"name", "params", "rettypes", "vararg"},
+        ForeignFunction = {"name", "params", "rettypes", "vararg"},
     }
 })
 
@@ -224,8 +224,8 @@ function types.tostring(t)
         end
     elseif tag == "Type.Typedef" then
         return t.name
-    elseif tag == "Type.Function" or tag == "Type.BuiltinFunction" then
-        local out = {tag == "Type.BuiltinFunction" and "builtin " or "", "function("}
+    elseif tag == "Type.Function" or tag == "Type.ForeignFunction" then
+        local out = {tag == "Type.ForeignFunction" and "foreign " or "", "function("}
         local ptypes = {}
         for _, param in ipairs(t.params) do
             table.insert(ptypes, types.tostring(param))
@@ -351,7 +351,7 @@ function types.serialize(t)
             "},{" ..table.concat(functions, ",") .. "}" .. "," ..
             "{" .. table.concat(methods, ",") .. "}" ..
             ")"
-    elseif tag == "Type.BuiltinFunction" then
+    elseif tag == "Type.ForeignFunction" then
         local ptypes = {}
         for _, pt in ipairs(t.params) do
             table.insert(ptypes, types.serialize(pt))
@@ -360,7 +360,7 @@ function types.serialize(t)
         for _, rt in ipairs(t.rettypes) do
             table.insert(rettypes, types.serialize(rt))
         end
-        return "BuiltinFunction('" .. t.name .. "'," ..
+        return "ForeignFunction('" .. t.name .. "'," ..
             "{" .. table.concat(ptypes, ",") .. "}" .. "," ..
             "{" .. table.concat(rettypes, ",") .. "}" .. "," ..
             tostring(t.vararg) .. ")"

--- a/titan-runtime/titan.c
+++ b/titan-runtime/titan.c
@@ -205,7 +205,7 @@ const TValue *getgeneric (Table *t, const TValue *key) {
   }
 }
 
-/* Builtins */
+/* Builtin foreign functions */
 int titan_print(lua_State *L, int nargs, ...) {
     if(nargs > 0) {
         lua_checkstack(L, 3);

--- a/titan-runtime/titan.c
+++ b/titan-runtime/titan.c
@@ -204,3 +204,126 @@ const TValue *getgeneric (Table *t, const TValue *key) {
     }
   }
 }
+
+/* Primitives */
+LUAI_FUNC int titan_print(lua_State *L, int nargs, ...) {
+    if(nargs > 0) {
+        lua_checkstack(L, 3);
+        TValue *top = L->top;
+        va_list args;
+        va_start(args, nargs);
+        for(int i = 0; i < nargs; i++) {
+            TValue val = va_arg(args, TValue);
+            setobj2s(L, L->top-1, &val);
+            size_t l;
+            const char *s = luaL_tolstring(L, -1, &l);
+            if(i > 0) lua_writestring("\t", 1);
+            lua_writestring(s, l);
+            L->top--;
+        }
+        va_end(args);
+        L->top = top;
+    }
+    lua_writeline();
+    return 0;
+}
+
+LUAI_FUNC TValue titan_assert(lua_State *L, TValue cond, TString *msg) {
+    if(l_isfalse(&cond)) {
+        luaL_error(L, getstr(msg));
+    }
+    return cond;
+}
+
+LUAI_FUNC Table *titan_dofile(lua_State *L, TString *fname, int nargs, ...) {
+    TValue *top = L->top;
+    lua_checkstack(L, 2 + nargs);
+    lua_createtable(L, 0, 0);
+    Table *tres = hvalue(L->top-1);
+    TValue *firstres = L->top;
+    if (luaL_loadfile(L, getstr(fname)) != LUA_OK) {
+        lua_error(L);
+    }
+    if(nargs > 0) {
+        va_list args;
+        va_start(args, nargs);
+        for(int i = 0; i < nargs; i++) {
+            TValue arg = va_arg(args, TValue);
+            L->top++;
+            setobj2s(L, L->top-1, &arg);
+        }
+        va_end(args);        
+    }
+    lua_call(L, nargs, LUA_MULTRET);
+    for(TValue *res = firstres; res < L->top; res++) {
+        luaH_setint(L, tres, res - firstres + 1, res);
+    }
+    L->top = top;
+    return tres;
+}
+
+LUAI_FUNC int titan_error(lua_State *L, TString *msg) {
+    return luaL_error(L, getstr(msg));
+}
+
+LUAI_FUNC Table *titan_dostring(lua_State *L, TString *code, int nargs, ...) {
+    TValue *top = L->top;
+    lua_checkstack(L, 2 + nargs);
+    lua_createtable(L, 0, 0);
+    Table *tres = hvalue(L->top-1);
+    TValue *firstres = L->top;
+    if (luaL_loadstring(L, getstr(code)) != LUA_OK) {
+        lua_error(L);
+    }
+    if(nargs > 0) {
+        va_list args;
+        va_start(args, nargs);
+        for(int i = 0; i < nargs; i++) {
+            TValue arg = va_arg(args, TValue);
+            L->top++;
+            setobj2s(L, L->top-1, &arg);
+        }
+        va_end(args);        
+    }
+    lua_call(L, nargs, LUA_MULTRET);
+    for(TValue *res = firstres; res < L->top; res++) {
+        luaH_setint(L, tres, res - firstres + 1, res);
+    }
+    L->top = top;
+    return tres;
+}
+
+LUAI_FUNC TString *titan_tostring(lua_State *L, TValue val) {
+    TValue *top = L->top;
+    lua_checkstack(L, 3);
+    L->top++;
+    setobj2s(L, L->top-1, &val);
+    size_t l;
+    luaL_tolstring(L, -1, &l);
+    TString *s = tsvalue(L->top-1);
+    L->top = top;
+    return s;
+}
+
+LUAI_FUNC lua_Number titan_tofloat(lua_State *L, TString *s) {
+    TValue val;
+    if(luaO_str2num(getstr(s), &val)) {
+        return nvalue(&val);
+    } else {
+        return 0;
+    }
+}
+
+LUAI_FUNC lua_Integer titan_tointeger(lua_State *L, TString *s) {
+    TValue val;
+    if(luaO_str2num(getstr(s), &val)) {
+        lua_Integer res;
+        if(luaV_tointeger(&val, &res, 0)) {
+            return res;
+        } else {
+            return 0;
+        }
+    } else {
+        return 0;
+    }
+}

--- a/titan-runtime/titan.c
+++ b/titan-runtime/titan.c
@@ -206,7 +206,7 @@ const TValue *getgeneric (Table *t, const TValue *key) {
 }
 
 /* Builtin foreign functions */
-int titan_print(lua_State *L, int nargs, ...) {
+int titan_print(lua_State *L, CClosure *_mod, int nargs, ...) {
     if(nargs > 0) {
         lua_checkstack(L, 3);
         TValue *top = L->top;
@@ -228,14 +228,14 @@ int titan_print(lua_State *L, int nargs, ...) {
     return 0;
 }
 
-TValue titan_assert(lua_State *L, TValue cond, TString *msg) {
+TValue titan_assert(lua_State *L, CClosure *_mod, TValue cond, TString *msg) {
     if(l_isfalse(&cond)) {
         luaL_error(L, getstr(msg));
     }
     return cond;
 }
 
-Table *titan_dofile(lua_State *L, TString *fname, int nargs, ...) {
+Table *titan_dofile(lua_State *L, CClosure *_mod, TString *fname, int nargs, ...) {
     TValue *top = L->top;
     lua_checkstack(L, 2 + nargs);
     lua_createtable(L, 0, 0);
@@ -262,11 +262,11 @@ Table *titan_dofile(lua_State *L, TString *fname, int nargs, ...) {
     return tres;
 }
 
-int titan_error(lua_State *L, TString *msg) {
+int titan_error(lua_State *L, CClosure *_mod, TString *msg) {
     return luaL_error(L, getstr(msg));
 }
 
-Table *titan_dostring(lua_State *L, TString *code, int nargs, ...) {
+Table *titan_dostring(lua_State *L, CClosure *_mod, TString *code, int nargs, ...) {
     TValue *top = L->top;
     lua_checkstack(L, 2 + nargs);
     lua_createtable(L, 0, 0);
@@ -293,7 +293,7 @@ Table *titan_dostring(lua_State *L, TString *code, int nargs, ...) {
     return tres;
 }
 
-TString *titan_tostring(lua_State *L, TValue val) {
+TString *titan_tostring(lua_State *L, CClosure *_mod, TValue val) {
     TValue *top = L->top;
     lua_checkstack(L, 3);
     L->top++;
@@ -305,7 +305,7 @@ TString *titan_tostring(lua_State *L, TValue val) {
     return s;
 }
 
-lua_Number titan_tofloat(lua_State *L, TString *s) {
+lua_Number titan_tofloat(lua_State *L, CClosure *_mod, TString *s) {
     TValue val;
     if(luaO_str2num(getstr(s), &val)) {
         return nvalue(&val);
@@ -314,7 +314,7 @@ lua_Number titan_tofloat(lua_State *L, TString *s) {
     }
 }
 
-lua_Integer titan_tointeger(lua_State *L, TString *s) {
+lua_Integer titan_tointeger(lua_State *L, CClosure *_mod, TString *s) {
     TValue val;
     if(luaO_str2num(getstr(s), &val)) {
         lua_Integer res;
@@ -328,7 +328,7 @@ lua_Integer titan_tointeger(lua_State *L, TString *s) {
     }
 }
 
-lua_Integer titan_string_byte(lua_State *L, TString *s, lua_Integer index) {
+lua_Integer titan_string_byte(lua_State *L, CClosure *_mod, TString *s, lua_Integer index) {
     size_t len = tsslen(s);
     if(index == 0)
         return 0;

--- a/titan-runtime/titan.c
+++ b/titan-runtime/titan.c
@@ -206,7 +206,7 @@ const TValue *getgeneric (Table *t, const TValue *key) {
 }
 
 /* Builtins */
-LUAI_FUNC int titan_print(lua_State *L, int nargs, ...) {
+int titan_print(lua_State *L, int nargs, ...) {
     if(nargs > 0) {
         lua_checkstack(L, 3);
         TValue *top = L->top;
@@ -228,14 +228,14 @@ LUAI_FUNC int titan_print(lua_State *L, int nargs, ...) {
     return 0;
 }
 
-LUAI_FUNC TValue titan_assert(lua_State *L, TValue cond, TString *msg) {
+TValue titan_assert(lua_State *L, TValue cond, TString *msg) {
     if(l_isfalse(&cond)) {
         luaL_error(L, getstr(msg));
     }
     return cond;
 }
 
-LUAI_FUNC Table *titan_dofile(lua_State *L, TString *fname, int nargs, ...) {
+Table *titan_dofile(lua_State *L, TString *fname, int nargs, ...) {
     TValue *top = L->top;
     lua_checkstack(L, 2 + nargs);
     lua_createtable(L, 0, 0);
@@ -262,11 +262,11 @@ LUAI_FUNC Table *titan_dofile(lua_State *L, TString *fname, int nargs, ...) {
     return tres;
 }
 
-LUAI_FUNC int titan_error(lua_State *L, TString *msg) {
+int titan_error(lua_State *L, TString *msg) {
     return luaL_error(L, getstr(msg));
 }
 
-LUAI_FUNC Table *titan_dostring(lua_State *L, TString *code, int nargs, ...) {
+Table *titan_dostring(lua_State *L, TString *code, int nargs, ...) {
     TValue *top = L->top;
     lua_checkstack(L, 2 + nargs);
     lua_createtable(L, 0, 0);
@@ -293,7 +293,7 @@ LUAI_FUNC Table *titan_dostring(lua_State *L, TString *code, int nargs, ...) {
     return tres;
 }
 
-LUAI_FUNC TString *titan_tostring(lua_State *L, TValue val) {
+TString *titan_tostring(lua_State *L, TValue val) {
     TValue *top = L->top;
     lua_checkstack(L, 3);
     L->top++;
@@ -305,7 +305,7 @@ LUAI_FUNC TString *titan_tostring(lua_State *L, TValue val) {
     return s;
 }
 
-LUAI_FUNC lua_Number titan_tofloat(lua_State *L, TString *s) {
+lua_Number titan_tofloat(lua_State *L, TString *s) {
     TValue val;
     if(luaO_str2num(getstr(s), &val)) {
         return nvalue(&val);
@@ -314,7 +314,7 @@ LUAI_FUNC lua_Number titan_tofloat(lua_State *L, TString *s) {
     }
 }
 
-LUAI_FUNC lua_Integer titan_tointeger(lua_State *L, TString *s) {
+lua_Integer titan_tointeger(lua_State *L, TString *s) {
     TValue val;
     if(luaO_str2num(getstr(s), &val)) {
         lua_Integer res;
@@ -326,4 +326,15 @@ LUAI_FUNC lua_Integer titan_tointeger(lua_State *L, TString *s) {
     } else {
         return 0;
     }
+}
+
+lua_Integer titan_string_byte(lua_State *L, TString *s, lua_Integer index) {
+    size_t len = tsslen(s);
+    if(index == 0)
+        return 0;
+    else if(index < 0) 
+        index = index % len; 
+    else 
+        index = (index - 1) % len;
+    return getstr(s)[index];
 }

--- a/titan-runtime/titan.c
+++ b/titan-runtime/titan.c
@@ -205,7 +205,7 @@ const TValue *getgeneric (Table *t, const TValue *key) {
   }
 }
 
-/* Primitives */
+/* Builtins */
 LUAI_FUNC int titan_print(lua_State *L, int nargs, ...) {
     if(nargs > 0) {
         lua_checkstack(L, 3);

--- a/titan-runtime/titan.h
+++ b/titan-runtime/titan.h
@@ -65,5 +65,6 @@ LUAI_FUNC Table *titan_dostring(lua_State *L, TString *code, int nargs, ...);
 LUAI_FUNC TString *titan_tostring(lua_State *L, TValue val);
 LUAI_FUNC lua_Number titan_tofloat(lua_State *L, TString *s);
 LUAI_FUNC lua_Integer titan_tointeger(lua_State *L, TString *s);
+LUAI_FUNC lua_Integer titan_string_byte(lua_State *L, TString *s, lua_Integer index);
 
 #endif

--- a/titan-runtime/titan.h
+++ b/titan-runtime/titan.h
@@ -56,7 +56,7 @@ LUAI_FUNC void *loadlib (lua_State *L, const char *file);
 LUAI_FUNC void *loadsym (lua_State *L, void *lib, const char *sym);
 LUAI_FUNC const TValue *getgeneric (Table *t, const TValue *key);
 
-/* Primitives */
+/* Builtins */
 LUAI_FUNC int titan_print(lua_State *L, int nargs, ...);
 LUAI_FUNC TValue titan_assert(lua_State *L, TValue cond, TString *msg);
 LUAI_FUNC Table *titan_dofile(lua_State *L, TString *fname, int nargs, ...);

--- a/titan-runtime/titan.h
+++ b/titan-runtime/titan.h
@@ -56,15 +56,4 @@ LUAI_FUNC void *loadlib (lua_State *L, const char *file);
 LUAI_FUNC void *loadsym (lua_State *L, void *lib, const char *sym);
 LUAI_FUNC const TValue *getgeneric (Table *t, const TValue *key);
 
-/* Builtins */
-LUAI_FUNC int titan_print(lua_State *L, int nargs, ...);
-LUAI_FUNC TValue titan_assert(lua_State *L, TValue cond, TString *msg);
-LUAI_FUNC Table *titan_dofile(lua_State *L, TString *fname, int nargs, ...);
-LUAI_FUNC int titan_error(lua_State *L, TString *msg);
-LUAI_FUNC Table *titan_dostring(lua_State *L, TString *code, int nargs, ...);
-LUAI_FUNC TString *titan_tostring(lua_State *L, TValue val);
-LUAI_FUNC lua_Number titan_tofloat(lua_State *L, TString *s);
-LUAI_FUNC lua_Integer titan_tointeger(lua_State *L, TString *s);
-LUAI_FUNC lua_Integer titan_string_byte(lua_State *L, TString *s, lua_Integer index);
-
 #endif

--- a/titan-runtime/titan.h
+++ b/titan-runtime/titan.h
@@ -56,4 +56,14 @@ LUAI_FUNC void *loadlib (lua_State *L, const char *file);
 LUAI_FUNC void *loadsym (lua_State *L, void *lib, const char *sym);
 LUAI_FUNC const TValue *getgeneric (Table *t, const TValue *key);
 
+/* Primitives */
+LUAI_FUNC int titan_print(lua_State *L, int nargs, ...);
+LUAI_FUNC TValue titan_assert(lua_State *L, TValue cond, TString *msg);
+LUAI_FUNC Table *titan_dofile(lua_State *L, TString *fname, int nargs, ...);
+LUAI_FUNC int titan_error(lua_State *L, TString *msg);
+LUAI_FUNC Table *titan_dostring(lua_State *L, TString *code, int nargs, ...);
+LUAI_FUNC TString *titan_tostring(lua_State *L, TValue val);
+LUAI_FUNC lua_Number titan_tofloat(lua_State *L, TString *s);
+LUAI_FUNC lua_Integer titan_tointeger(lua_State *L, TString *s);
+
 #endif

--- a/titanc
+++ b/titanc
@@ -49,18 +49,18 @@ end
 
 if #errors > 0 then exit(table.concat(errors, "\n")) end
 
-local libnames = {}
+local modnames = {}
 for name, mod in pairs(driver.imported) do
-    local ok, err, libname = driver.compile_module(name, mod, args.link, main_module ~= nil, args.verbose)
+    local ok, err = driver.compile_module(name, mod, args.link, main_module ~= nil, args.verbose)
     if not ok then
         table.insert(errors, err)
     else
-        table.insert(libnames, libname)
+        table.insert(modnames, name)
     end
 end
 
 if main_module then
-    driver.compile_program(main_module, libnames, args.link, args.verbose)
+    driver.compile_program(main_module, modnames, args.link, args.verbose)
 end
 
 if #errors > 0 then exit(table.concat(errors, "\n")) end


### PR DESCRIPTION
Adds the capability of having builtin functions in the Titan runtime that are callable directly from Titan code, and defines a few builtins available to all Titan modules (such as `print`).

The idea is to use builtin functions for standard library functions that need to access Titan's Lua state, and for functions that do not need to access the Lua state but where it is incovenient or impossible to define the function by a combination of Titan code plus FFI calls.

These builtin functions have the Titan calling convention, apart from the addition of variadic arguments, encoded as an `int` parameter that takes the size of the variadic argument list, and a standard C variadic parameter.

The C name of a builtin function is always `titan_<name>` for the builtins that are not part of any module, such as `print` and `tostring`, and `titan_<mangled_fqtn>` for builtins declared in as part of a module, where `mangled_fqtn` is the fully-qualified name of the function with all dashes and dots replaced by underscores.