### PR TITLE
No C global state in modules

### DIFF
--- a/titan-compiler/coder.lua
+++ b/titan-compiler/coder.lua
@@ -2981,24 +2981,6 @@ function coder.generate(modname, ast, is_dynamic)
         }))
     end
 
-    local nslots = initctx.nslots
-
-    table.insert(initvars, 1, render([[
-        /* reserve needed stack space */
-        if (L->stack_last - L->top > $NSLOTS) {
-            if (L->ci->top < L->top + $NSLOTS) L->ci->top = L->top + $NSLOTS;
-        } else {
-            lua_checkstack(L, $NSLOTS);
-        }
-        TValue *_base = L->top;
-        L->top += $NSLOTS;
-        for(TValue *_s = L->top - 1; _base <= _s; _s--) {
-            setnilvalue(_s);
-        }
-    ]], {
-        NSLOTS = c_integer_literal(nslots),
-    }))
-
     table.insert(code, render(modtypes, {
         TYPESNAME = tlcontext.prefix .. "types",
         TYPES = string.format("%q", types.serialize(ast._type))


### PR DESCRIPTION
This PR removes most of the C global state in Titan modules, the only thing that is left is a cache for tags. We are passing all the tests that we currently have, but I still need to write tests for functionality that this PR enables, such as loading the same Titan module from two distinct Lua states (their module variables will be local to the state, as it should be), or linking module B inside module A.so, while having a separate B.so, and having the B that A imports and the other B require'd by Lua refer to the same module instance.

The canonical module instances for each Lua state, as well the canonical tags and metatables for record types, are kept in the Lua registry, but we only need to hit the registry at module initialization, no accesses to the registry are done on normal execution of Titan code.

One thing that we lose is the ability to leverage GCC's constant propagation to propagate local module variables that have numeric values that can be know at compile-time, but we can add a constant propagation AST->AST pass later on.