### PR TITLE
Fix undeclared external functions

### DIFF
--- a/spec/checker_spec.lua
+++ b/spec/checker_spec.lua
@@ -1739,6 +1739,23 @@ describe("Titan type checker", function()
         assert.match("'foo.a' is not a function", err)
     end)
 
+    it("catches call of undeclared external function", function ()
+        local modules = {
+            foo = [[
+                a: integer = 1
+            ]],
+            bar = [[
+                local foo = import "foo"
+                function bar(): integer
+                    return foo.b()
+                end
+            ]]
+        }
+        local ok, err, mods = run_checker_modules(modules, "bar")
+        assert.falsy(ok)
+        assert.match("member 'b' not found inside module 'foo'", err)
+    end)
+
     it("catches call of non-function function", function ()
         local code = [[
             local a = 2

--- a/titan-compiler/checker.lua
+++ b/titan-compiler/checker.lua
@@ -435,7 +435,7 @@ checkvar = util.make_visitor({
         if ltype._tag == "Type.Module" or ltype._tag == "Type.ForeignModule" then
             local mod = ltype
             if not mod.members[node.name] then
-                checker.typeerror(errors, node.loc,
+                node._type = invalid(errors, node.loc,
                     "member '%s' not found inside module '%s'",
                     node.name, mod.name)
             else
@@ -1026,6 +1026,10 @@ checkexp = util.make_visitor({
         end
         if node.args._tag == "Ast.ArgsFunc" then
             local ftype = node.exp._type
+            if ftype._tag == "Type.Invalid" then
+                node._type = ftype
+                return
+            end
             local fname = expname(node.exp)
             local var = node.exp.var
             if not (var and var._decl and (var._decl._tag == "Ast.TopLevelFunc" or


### PR DESCRIPTION
Two commits cherry-picked from the `pacman-wip` branch.

The first one makes a small refactor aiming to improve the propagation of the "invalid" types. The second one is a bug fix in one instance where the invalid type was not being propagated, including a regression test.
