### PR TITLE
fix header parser for OS X

### DIFF
--- a/c-parser/cdriver.lua
+++ b/c-parser/cdriver.lua
@@ -13,9 +13,9 @@ function cdriver.process_file(filename)
 
     local srccode = table.concat(ctx.output, "\n").." $EOF$"
 
-    local res, err, line, col = c99.match_language_grammar(srccode)
+    local res, err, line, col, fragment = c99.match_language_grammar(srccode)
     if not res then
-        return nil, ("failed parsing: %s:%d:%d: %s\n"):format(filename, line, col, err)
+        return nil, ("failed parsing: %s:%d:%d: %s\n%s"):format(filename, line, col, err, fragment)
     end
 
     local ffi_types, err = ctypes.register_types(res)

--- a/c-parser/cpp.lua
+++ b/c-parser/cpp.lua
@@ -704,6 +704,11 @@ cpp.parse_file = typed("string, FILE*?, Ctx? -> Ctx?, string?", function(filenam
                 local is_next = (tk.directive == "include_next")
                 local inc_filename, inc_fd, err = find_file(ctx, name, mode, is_next)
                 if not inc_filename then
+                    -- fall back to trying to load an #include "..." as #include <...>;
+                    -- this is necessary for Mac system headers
+                    inc_filename, inc_fd, err = find_file(ctx, name, "system", is_next)
+                end
+                if not inc_filename then
                     return nil, name..":"..err
                 end
                 cpp.parse_file(inc_filename, inc_fd, ctx)


### PR DESCRIPTION
OS X system headers have a bunch of custom attributes that do not mimic exactly the syntax of GCC attributes in the Linux headers, so make the parser more permissive to get around that (the parser ignores attributes anyway).

One of the OS X headers also uses `#include "..."` expecting the include file to be found in the same search path as the regular `#include <...>`, we work around that (probably not in the best way).

Finally, one of the OS X system headers has a function that takes a block, we now accept that and treat it just as a regular function pointer.