### PR TITLE
titanc: bail out of code generation on type errors

### DIFF
--- a/titanc
+++ b/titanc
@@ -51,6 +51,8 @@ for _, modname in ipairs(args.module) do
     end
 end
 
+if #errors > 0 then exit(table.concat(errors, "\n")) end
+
 local libnames = {}
 
 for name, mod in pairs(driver.imported) do


### PR DESCRIPTION
Fix for the odd behavior of `titanc` in Issue #245. Does not actually fix the underlying problem (missing `examples/sdl_quit.titan`), but will keep `titanc` from trying to compile files that have type errors (in this case a missing `import`).