### PR TITLE
fix some regressions with option types

### DIFF
--- a/spec/checker_spec.lua
+++ b/spec/checker_spec.lua
@@ -325,6 +325,16 @@ describe("Titan type checker", function()
         ]])
     end)
 
+    it("coerces option in index", function ()
+        assert_type_check([[
+            function fn()
+                local a: { {string} } = { { 'foo' } }
+                local s = a[1][1]
+                a[1][1] = s
+            end
+        ]])
+    end)
+
     it("typechecks multiple return values in array initialization", function ()
         local code = [[
             function f(): (integer, integer)

--- a/spec/coder_spec.lua
+++ b/spec/coder_spec.lua
@@ -2310,7 +2310,7 @@ describe("Titan code generator", function()
             ]])
         end)
 
-        it("compares two options", function ()
+        it("compares two values with option types", function ()
             run_coder([[
                 function fn(a: integer, b: integer): boolean
                   local t1 = { a }

--- a/spec/coder_spec.lua
+++ b/spec/coder_spec.lua
@@ -2310,6 +2310,18 @@ describe("Titan code generator", function()
             ]])
         end)
 
+        it("compares two options", function ()
+            run_coder([[
+                function fn(a: integer, b: integer): boolean
+                  local t1 = { a }
+                  local t2 = { b }
+                  return t1[1] ~= t2[1]
+                end
+            ]], [[
+                assert(test.fn(1, 2))
+                assert(not test.fn(1, 1))
+            ]])
+        end)
     end)
 
     describe("#apps", function()

--- a/titan-compiler/checker.lua
+++ b/titan-compiler/checker.lua
@@ -540,6 +540,7 @@ checkvar = util.make_visitor({
 
     ["Ast.VarBracket"] = function(node, st, errors, context)
         checkexp(node.exp1, st, errors)
+        node.exp1 = tryforce(node.exp1)
         local keystype, term
         if node.exp1._type._tag == "Type.Array" then
             node._type = optionize(node.exp1._type.elem)

--- a/titan-compiler/coder.lua
+++ b/titan-compiler/coder.lua
@@ -1915,8 +1915,8 @@ local function codebinaryop(ctx, node, iscondition)
             error("impossible: " .. ltyp .. " " .. rtyp)
         end
     elseif (op == "==" or op == "!=") and
-            node.lhs._type._tag == "Type.Value" and
-            node.rhs._type._tag == "Type.Value" then
+            ctype(node.lhs._type) == "TValue" and
+            ctype(node.rhs._type) == "TValue" then
         local lstats, lcode = codeexp(ctx, node.lhs)
         local rstats, rcode = codeexp(ctx, node.rhs)
         if op == "!=" then


### PR DESCRIPTION
Option types introduced some regressions, this PR fixes them and adds tests for those cases. 

First regression was indexing an array of arrays, the type checker was not coercing the option in the `e1` part of `e1[e2]` to its non-option version, so code like `x[...][...]` was failing because `x[...]` did not have an array type.

Second regression was comparing two option types, which should be like comparing two `value`s. Code like `a[1] == b[1]` that used to work now was having generating wrong C code because it was trying to compare two `TValue`s (the underlying C type of Lua slots and Titan option types) directly using `==`.
