### PR TITLE
Restore TableFormatLevel after parser_spec tests

### DIFF
--- a/spec/parser_spec.lua
+++ b/spec/parser_spec.lua
@@ -131,6 +131,21 @@ end
 --
 
 describe("Titan parser", function()
+    local ORIGINAL_FORMAT_LEVEL
+
+    setup(function()
+        -- Print the whole AST when it doesn't match, instead of just a handful
+        -- of nodes. A depth of 100 should be more than enough. Although the
+        -- luassert docs suggest -1 to show an infinite number of levels, that
+        -- can get stuck in an infinite loop if we have self-referential tables.
+        ORIGINAL_FORMAT_LEVEL = assert:get_parameter("TableFormatLevel")
+        assert:set_parameter("TableFormatLevel", 100)
+    end)
+
+    teardown(function()
+        assert:set_parameter("TableFormatLevel", ORIGINAL_FORMAT_LEVEL)
+    end)
+
     assert:set_parameter("TableFormatLevel", -1)
 
     it("can parse programs starting with whitespace or comments", function()


### PR DESCRIPTION
When we set the TableFormatLevel to infinite in the parser spec, that setting
carried on to the other spec files that ran after it. This turned out to be a
problem because after the scope_analysis step out AST contains self-referential
references. This meant that an attempt to print the AST in these test files (as
may happen in failing test cases) would cause busted to get stuck into an
infinite loop (and cause the machine to start swapping).

This was really tricky to find out, because the problem doesn't occur when
running individual test files, only when running the whole test suite.

This is a port of https://github.com/pallene-lang/pallene/pull/46